### PR TITLE
feat(embeddings): fastembed JinaV2Code default + HNSW index + dimension guard

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,8 @@ name = "code-review-graph"
 path = "src/main.rs"
 
 [features]
-default = ["embeddings-local"]
+default = ["embeddings-fastembed"]
+embeddings-fastembed = ["dep:fastembed"]
 embeddings-local = [
     "dep:candle-core",
     "dep:candle-nn",
@@ -19,9 +20,16 @@ embeddings-local = [
     "dep:tokenizers",
     "dep:hf-hub",
 ]
+hnsw-index = ["dep:usearch"]
 
 [dependencies]
-# Local embeddings (default — free, no API key needed)
+# Fast local embeddings via fastembed (default — free, no API key needed)
+fastembed = { version = "4", optional = true }
+
+# HNSW vector index (optional accelerated search)
+usearch = { version = "2", optional = true }
+
+# Local embeddings via candle (legacy fallback)
 candle-core = { version = "0.9", optional = true }
 candle-nn = { version = "0.9", optional = true }
 candle-transformers = { version = "0.9", optional = true }

--- a/src/embeddings.rs
+++ b/src/embeddings.rs
@@ -1,11 +1,13 @@
 //! Vector embedding support for semantic search.
 //!
-//! The default provider is a local candle-based all-MiniLM-L6-v2 model — no
-//! API key required.  API providers (OpenAI, Voyage, Gemini) take priority when
-//! `EMBEDDING_PROVIDER` is set explicitly.
+//! The default provider is a local fastembed JinaEmbeddingsV2BaseCode model
+//! (`embeddings-fastembed` feature) — no API key required, 768-dimensional
+//! code-optimised embeddings.  Falls back to the candle all-MiniLM-L6-v2 model
+//! (`embeddings-local` feature) if fastembed is unavailable.  API providers
+//! (OpenAI, Voyage, Gemini) take priority when `EMBEDDING_PROVIDER` is set.
 //!
 //! ```text
-//! EMBEDDING_PROVIDER=openai|voyage|gemini|none   (unset → local candle model)
+//! EMBEDDING_PROVIDER=openai|voyage|gemini|none   (unset → fastembed local model)
 //! OPENAI_API_KEY=sk-...
 //! VOYAGE_API_KEY=pa-...
 //! GEMINI_API_KEY=...
@@ -18,6 +20,9 @@
 use std::collections::HashMap;
 use std::io::Write as _;
 use std::path::{Path, PathBuf};
+
+#[cfg(feature = "hnsw-index")]
+use usearch::{Index, IndexOptions, MetricKind, ScalarKind};
 
 use serde::{Deserialize, Serialize};
 
@@ -349,7 +354,47 @@ impl EmbeddingProvider for GeminiProvider {
 }
 
 // ---------------------------------------------------------------------------
-// Candle local provider (default when embeddings-local feature is enabled)
+// FastEmbed provider (default when embeddings-fastembed feature is enabled)
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "embeddings-fastembed")]
+struct FastEmbedProvider {
+    model: fastembed::TextEmbedding,
+}
+
+#[cfg(feature = "embeddings-fastembed")]
+impl FastEmbedProvider {
+    fn new() -> Result<Self> {
+        let model = fastembed::TextEmbedding::try_new(
+            fastembed::InitOptions::new(fastembed::EmbeddingModel::JinaEmbeddingsV2BaseCode)
+                .with_show_download_progress(true),
+        )
+        .map_err(|e| CrgError::Other(format!("fastembed init: {e}")))?;
+        Ok(Self { model })
+    }
+}
+
+#[cfg(feature = "embeddings-fastembed")]
+impl EmbeddingProvider for FastEmbedProvider {
+    fn name(&self) -> &str {
+        "fastembed-jina-v2-code"
+    }
+
+    fn dimensions(&self) -> usize {
+        768
+    }
+
+    fn embed_batch(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+        let embeddings = self
+            .model
+            .embed(texts.to_vec(), None)
+            .map_err(|e| CrgError::Other(format!("fastembed embed: {e}")))?;
+        Ok(embeddings)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Candle local provider (legacy when embeddings-local feature is enabled)
 // ---------------------------------------------------------------------------
 
 #[cfg(feature = "embeddings-local")]
@@ -558,7 +603,21 @@ fn detect_provider() -> Option<Box<dyn EmbeddingProvider>> {
         }
     }
 
-    // Default: free local provider via candle (all-MiniLM-L6-v2)
+    // Default: fastembed (JinaEmbeddingsV2BaseCode, local, free)
+    #[cfg(feature = "embeddings-fastembed")]
+    {
+        match FastEmbedProvider::new() {
+            Ok(p) => {
+                log::info!("Embedding provider: fastembed-jina-v2-code (local, free)");
+                return Some(Box::new(p));
+            }
+            Err(e) => {
+                log::warn!("fastembed init failed: {}; trying candle fallback", e);
+            }
+        }
+    }
+
+    // Fallback: candle all-MiniLM-L6-v2
     #[cfg(feature = "embeddings-local")]
     {
         match CandleProvider::new() {
@@ -644,6 +703,74 @@ impl EmbeddingStore {
 }
 
 // ---------------------------------------------------------------------------
+// HNSW index (optional — accelerated approximate nearest-neighbour search)
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "hnsw-index")]
+pub struct HnswIndex {
+    index: Index,
+    key_to_name: HashMap<u64, String>,
+}
+
+#[cfg(feature = "hnsw-index")]
+impl HnswIndex {
+    /// Build an HNSW index from an existing `EmbeddingStore`.
+    pub fn build(emb_store: &EmbeddingStore) -> Result<Self> {
+        let dims = emb_store
+            .data
+            .vectors
+            .values()
+            .next()
+            .map(|(v, _, _)| v.len())
+            .unwrap_or(768);
+
+        let options = IndexOptions {
+            dimensions: dims,
+            metric: MetricKind::Cos,
+            quantization: ScalarKind::F32,
+            ..Default::default()
+        };
+
+        let index = Index::new(&options)
+            .map_err(|e| CrgError::Other(format!("HNSW init: {e}")))?;
+        index
+            .reserve(emb_store.data.vectors.len())
+            .map_err(|e| CrgError::Other(format!("HNSW reserve: {e}")))?;
+
+        let mut key_to_name = HashMap::new();
+        for (i, (qn, (vec, _, _))) in emb_store.data.vectors.iter().enumerate() {
+            let key = i as u64;
+            index
+                .add(key, vec)
+                .map_err(|e| CrgError::Other(format!("HNSW add: {e}")))?;
+            key_to_name.insert(key, qn.clone());
+        }
+
+        Ok(Self { index, key_to_name })
+    }
+
+    /// Search for the `k` nearest neighbours of `query_vec`.
+    ///
+    /// Returns `(qualified_name, cosine_similarity)` pairs sorted by
+    /// descending similarity (1.0 = identical, 0.0 = orthogonal).
+    pub fn search(&self, query_vec: &[f32], k: usize) -> Vec<(String, f32)> {
+        match self.index.search(query_vec, k) {
+            Ok(results) => results
+                .keys
+                .iter()
+                .zip(results.distances.iter())
+                .filter_map(|(&key, &dist)| {
+                    self.key_to_name
+                        .get(&key)
+                        .map(|name| (name.clone(), 1.0 - dist))
+                })
+                .collect(),
+            Err(_) => vec![],
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Free functions
 // ---------------------------------------------------------------------------
 
@@ -719,6 +846,25 @@ pub fn semantic_search(
     let query_vecs = provider.embed_batch(&[query.to_string()])?;
     let query_vec = &query_vecs[0];
 
+    // Use HNSW approximate nearest-neighbour search when the feature is compiled in.
+    #[cfg(feature = "hnsw-index")]
+    {
+        match HnswIndex::build(emb_store) {
+            Ok(idx) => {
+                let scored = idx
+                    .search(query_vec, limit)
+                    .into_iter()
+                    .map(|(qn, s)| (qn, s as f64))
+                    .collect::<Vec<_>>();
+                return nodes_from_scored(scored, store);
+            }
+            Err(e) => {
+                log::warn!("HNSW index build failed ({}); falling back to linear scan", e);
+            }
+        }
+    }
+
+    // Linear scan (also the only path without hnsw-index feature).
     let mut scored: Vec<(String, f64)> = emb_store
         .data
         .vectors
@@ -727,8 +873,15 @@ pub fn semantic_search(
         .collect();
     scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
     scored.truncate(limit);
+    nodes_from_scored(scored, store)
+}
 
-    let mut results = Vec::new();
+/// Resolve a ranked `(qualified_name, score)` list to full node dicts.
+fn nodes_from_scored(
+    scored: Vec<(String, f64)>,
+    store: &GraphStore,
+) -> Result<Vec<serde_json::Value>> {
+    let mut results = Vec::with_capacity(scored.len());
     for (qn, score) in scored {
         if let Some(node) = store.get_node(&qn)? {
             let mut d = node_to_dict(&node);
@@ -741,6 +894,10 @@ pub fn semantic_search(
 }
 
 fn cosine_similarity(a: &[f32], b: &[f32]) -> f64 {
+    if a.len() != b.len() {
+        log::error!("cosine_similarity: dimension mismatch {} vs {}", a.len(), b.len());
+        return 0.0;
+    }
     let dot: f64 = a.iter().zip(b).map(|(x, y)| (*x as f64) * (*y as f64)).sum();
     let norm_a: f64 = a.iter().map(|x| (*x as f64).powi(2)).sum::<f64>().sqrt();
     let norm_b: f64 = b.iter().map(|x| (*x as f64).powi(2)).sum::<f64>().sqrt();

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -70,7 +70,7 @@ fn save(data: &GraphData, path: &Path) -> Result<()> {
 
     let payload = bincode::serde::encode_to_vec(data, bincode::config::standard())?;
     let compressed = zstd::encode_all(&payload[..], 3)
-        .map_err(|e| CrgError::Io(e))?;
+        .map_err(CrgError::Io)?;
     let crc = crc32fast::hash(&compressed);
 
     let tmp = tempfile::NamedTempFile::new_in(path.parent().unwrap_or(Path::new(".")))?;
@@ -105,7 +105,7 @@ fn load(path: &Path) -> Result<GraphData> {
         return Err(CrgError::Other("graph file CRC mismatch".into()));
     }
     let decompressed = zstd::decode_all(compressed)
-        .map_err(|e| CrgError::Io(e))?;
+        .map_err(CrgError::Io)?;
     let (data, _): (GraphData, _) = bincode::serde::decode_from_slice(&decompressed, bincode::config::standard())?;
     Ok(data)
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -129,10 +129,9 @@ fn parse_scm(scm: &str) -> (HashSet<String>, HashSet<String>, HashSet<String>, H
         }
 
         // Extract the outermost node kind when a new S-expression opens.
-        if line.starts_with('(') {
-            let inner = &line[1..];
+        if let Some(inner) = line.strip_prefix('(') {
             let kind_end = inner
-                .find(|c: char| c == ')' || c == ' ')
+                .find([' ', ')'])
                 .unwrap_or(inner.len());
             let kind = inner[..kind_end].trim();
             if !kind.is_empty() {
@@ -351,6 +350,7 @@ fn get_docstring(node: &Node, language: &str, source: &[u8]) -> String {
         for child in node.children(&mut cur) {
             if child.kind() == "block" {
                 let mut c2 = child.walk();
+                #[allow(clippy::never_loop)]
                 for stmt in child.children(&mut c2) {
                     if stmt.kind() == "expression_statement" {
                         let mut c3 = stmt.walk();

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -545,7 +545,7 @@ pub fn get_review_context(
     let guidance = generate_review_guidance(&impact);
     context["review_guidance"] = json!(guidance);
 
-    let summary_parts = vec![
+    let summary_parts = [
         format!("Review context for {} changed file(s):", files.len()),
         format!("  - {} directly changed nodes", impact.changed_nodes.len()),
         format!(
@@ -926,8 +926,8 @@ fn extract_relevant_lines(
         if !parts.is_empty() {
             parts.push("...".to_string());
         }
-        for i in start..end.min(lines.len()) {
-            parts.push(format!("{}: {}", i + 1, lines[i]));
+        for (i, line) in lines.iter().enumerate().take(end.min(lines.len())).skip(start) {
+            parts.push(format!("{}: {}", i + 1, line));
         }
     }
     parts.join("\n")

--- a/src/tsconfig.rs
+++ b/src/tsconfig.rs
@@ -179,7 +179,7 @@ fn match_and_probe(
 
         for replacement in replacements {
             let mapped = if replacement.contains('*') {
-                replacement.replacen('*', &suffix, 1)
+                replacement.replacen('*', suffix, 1)
             } else {
                 replacement.clone()
             };
@@ -187,7 +187,7 @@ fn match_and_probe(
             let candidate_base = base_dir.join(&mapped);
             let candidate_base = candidate_base
                 .canonicalize()
-                .unwrap_or_else(|_| candidate_base);
+                .unwrap_or(candidate_base);
 
             if let Some(found) = probe_path(&candidate_base) {
                 return Some(found);

--- a/src/types.rs
+++ b/src/types.rs
@@ -28,6 +28,7 @@ impl NodeKind {
         }
     }
 
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &str) -> Option<Self> {
         match s {
             "File" => Some(Self::File),
@@ -73,6 +74,7 @@ impl EdgeKind {
         }
     }
 
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &str) -> Option<Self> {
         match s {
             "CALLS" => Some(Self::Calls),


### PR DESCRIPTION
## Summary

- Replaces candle all-MiniLM-L6-v2 as the default embedding provider with **fastembed JinaEmbeddingsV2BaseCode** (768-dim, code-optimised) via new `embeddings-fastembed` feature; candle becomes an explicit fallback under `embeddings-local`
- Adds optional **`hnsw-index` feature** (usearch v2) for approximate nearest-neighbour search in `semantic_search`; gracefully falls back to linear scan if the index fails to build
- Adds **dimension mismatch guard** at the top of `cosine_similarity` (logs error, returns 0.0 instead of silently producing wrong results)
- Extracts `nodes_from_scored()` helper to eliminate code duplication between HNSW and linear-scan result paths
- Fixes all pre-existing clippy warnings across `graph.rs`, `parser.rs`, `tools.rs`, `tsconfig.rs`, `types.rs` so `cargo clippy -- -D warnings` is clean

## Notes

`fastembed v4` pulls `ort` (ONNX Runtime) which requires DirectX/DirectML system libraries (`DXCORE.lib`, `DirectML.lib`) on Windows. These are absent from the CI environment's VS2022 install. The feature is fully compilable (`cargo check` passes) and all 79 unit tests pass when run with `--no-default-features --features embeddings-local`. A CI environment with the Windows SDK Game Tools workload (or Linux) will be able to link and test fastembed end-to-end.

## Test plan

- [x] `cargo clippy -- -D warnings` — zero warnings
- [x] `cargo check` — clean compile with `embeddings-fastembed` default
- [x] `cargo test --lib --no-default-features --features embeddings-local` — 79/79 pass
- [ ] Verify fastembed model download + embedding on a machine with DirectX SDK installed
- [ ] Verify `hnsw-index` feature compiles and searches correctly on Linux