### PR TITLE
feat: add compact response mode to MCP tools

### DIFF
--- a/src/embeddings.rs
+++ b/src/embeddings.rs
@@ -810,12 +810,13 @@ pub fn semantic_search(
     store: &GraphStore,
     emb_store: &mut EmbeddingStore,
     limit: usize,
+    compact: bool,
 ) -> Result<Vec<serde_json::Value>> {
     let provider = match &emb_store.provider {
         Some(p) => p,
         None => {
             let nodes = store.search_nodes(query, limit)?;
-            return Ok(nodes.iter().map(node_to_dict).collect());
+            return Ok(nodes.iter().map(|n| node_to_dict(n, compact)).collect());
         }
     };
 
@@ -832,7 +833,7 @@ pub fn semantic_search(
                     .into_iter()
                     .map(|(qn, s)| (qn, s as f64))
                     .collect::<Vec<_>>();
-                return nodes_from_scored(scored, store);
+                return nodes_from_scored(scored, store, compact);
             }
             Err(e) => {
                 log::warn!("HNSW index build failed ({}); falling back to linear scan", e);
@@ -849,18 +850,19 @@ pub fn semantic_search(
         .collect();
     scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
     scored.truncate(limit);
-    nodes_from_scored(scored, store)
+    nodes_from_scored(scored, store, compact)
 }
 
 /// Resolve a ranked `(qualified_name, score)` list to full node dicts.
 fn nodes_from_scored(
     scored: Vec<(String, f64)>,
     store: &GraphStore,
+    compact: bool,
 ) -> Result<Vec<serde_json::Value>> {
     let mut results = Vec::with_capacity(scored.len());
     for (qn, score) in scored {
         if let Some(node) = store.get_node(&qn)? {
-            let mut d = node_to_dict(&node);
+            let mut d = node_to_dict(&node, compact);
             d["similarity_score"] =
                 serde_json::Value::from((score * 10_000.0).round() / 10_000.0);
             results.push(d);

--- a/src/server.rs
+++ b/src/server.rs
@@ -55,6 +55,9 @@ struct ImpactRadiusParams {
     #[schemars(description = "Git ref for auto-detecting changes")]
     #[serde(default = "default_base")]
     base: String,
+    #[schemars(description = "If true, return slim node objects (name, qualified_name, kind, file_path, line_start, line_end, signature only). Reduces response tokens ~40%.")]
+    #[serde(default)]
+    compact: bool,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -66,6 +69,9 @@ struct QueryGraphParams {
     #[schemars(description = "Repository root path. Auto-detected if omitted.")]
     #[serde(default)]
     repo_root: Option<String>,
+    #[schemars(description = "If true, return slim node objects (name, qualified_name, kind, file_path, line_start, line_end, signature only). Reduces response tokens ~40%.")]
+    #[serde(default)]
+    compact: bool,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -88,6 +94,9 @@ struct ReviewContextParams {
     #[schemars(description = "Git ref for change detection")]
     #[serde(default = "default_base")]
     base: String,
+    #[schemars(description = "If true, return slim node objects (name, qualified_name, kind, file_path, line_start, line_end, signature only). Reduces response tokens ~40%.")]
+    #[serde(default)]
+    compact: bool,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -103,6 +112,9 @@ struct SemanticSearchParams {
     #[schemars(description = "Repository root path. Auto-detected if omitted.")]
     #[serde(default)]
     repo_root: Option<String>,
+    #[schemars(description = "If true, return slim node objects (name, qualified_name, kind, file_path, line_start, line_end, signature only). Reduces response tokens ~40%.")]
+    #[serde(default)]
+    compact: bool,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -142,6 +154,9 @@ struct LargeFunctionsParams {
     #[schemars(description = "Repository root path. Auto-detected if omitted.")]
     #[serde(default)]
     repo_root: Option<String>,
+    #[schemars(description = "If true, return slim node objects (name, qualified_name, kind, file_path, line_start, line_end, signature only). Reduces response tokens ~40%.")]
+    #[serde(default)]
+    compact: bool,
 }
 
 // Default value helpers
@@ -235,6 +250,7 @@ impl CodeReviewServer {
                 p.max_depth,
                 repo_root.as_deref(),
                 &p.base,
+                p.compact,
             )
             .map(|v| v.to_string())
             .map_err(|e| e.to_string())
@@ -258,6 +274,7 @@ impl CodeReviewServer {
                 &p.pattern,
                 &p.target,
                 repo_root.as_deref(),
+                p.compact,
             )
             .map(|v| v.to_string())
             .map_err(|e| e.to_string())
@@ -284,6 +301,7 @@ impl CodeReviewServer {
                 p.max_lines_per_file,
                 repo_root.as_deref(),
                 &p.base,
+                p.compact,
             )
             .map(|v| v.to_string())
             .map_err(|e| e.to_string())
@@ -308,6 +326,7 @@ impl CodeReviewServer {
                 p.kind.as_deref(),
                 p.limit,
                 repo_root.as_deref(),
+                p.compact,
             )
             .map(|v| v.to_string())
             .map_err(|e| e.to_string())
@@ -392,6 +411,7 @@ impl CodeReviewServer {
                 p.file_path_pattern.as_deref(),
                 p.limit,
                 repo_root.as_deref(),
+                p.compact,
             )
             .map(|v| v.to_string())
             .map_err(|e| e.to_string())

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -211,6 +211,7 @@ pub fn get_impact_radius(
     max_depth: usize,
     repo_root: Option<&str>,
     base: &str,
+    compact: bool,
 ) -> Result<Value> {
     const MAX_RESULTS: usize = 500;
     let (mut store, root) = get_store(repo_root)?;
@@ -237,8 +238,8 @@ pub fn get_impact_radius(
 
     let impact = store.get_impact_radius(&abs_files, max_depth, MAX_RESULTS, None)?;
 
-    let changed_dicts: Vec<Value> = impact.changed_nodes.iter().map(node_to_dict).collect();
-    let impacted_dicts: Vec<Value> = impact.impacted_nodes.iter().map(node_to_dict).collect();
+    let changed_dicts: Vec<Value> = impact.changed_nodes.iter().map(|n| node_to_dict(n, compact)).collect();
+    let impacted_dicts: Vec<Value> = impact.impacted_nodes.iter().map(|n| node_to_dict(n, compact)).collect();
     let edge_dicts: Vec<Value> = impact.edges.iter().map(edge_to_dict).collect();
 
     let mut summary_parts = vec![
@@ -350,6 +351,7 @@ pub fn query_graph(
     pattern: &str,
     target: &str,
     repo_root: Option<&str>,
+    compact: bool,
 ) -> Result<Value> {
     let (mut store, root) = get_store(repo_root)?;
     maybe_auto_update(&mut store, &root);
@@ -423,7 +425,7 @@ pub fn query_graph(
             for e in store.get_edges_by_target(&qn)? {
                 if e.kind == EdgeKind::Calls {
                     if let Some(caller) = store.get_node(&e.source_qualified)? {
-                        results.push(node_to_dict(&caller));
+                        results.push(node_to_dict(&caller, compact));
                     }
                     edges_out.push(edge_to_dict(&e));
                 }
@@ -433,7 +435,7 @@ pub fn query_graph(
                 if let Some(ref n) = node {
                     for e in store.search_edges_by_target_name(&n.name)? {
                         if let Some(caller) = store.get_node(&e.source_qualified)? {
-                            results.push(node_to_dict(&caller));
+                            results.push(node_to_dict(&caller, compact));
                         }
                         edges_out.push(edge_to_dict(&e));
                     }
@@ -444,7 +446,7 @@ pub fn query_graph(
             for e in store.get_edges_by_source(&qn)? {
                 if e.kind == EdgeKind::Calls {
                     if let Some(callee) = store.get_node(&e.target_qualified)? {
-                        results.push(node_to_dict(&callee));
+                        results.push(node_to_dict(&callee, compact));
                     }
                     edges_out.push(edge_to_dict(&e));
                 }
@@ -473,7 +475,7 @@ pub fn query_graph(
             for e in store.get_edges_by_source(&qn)? {
                 if e.kind == EdgeKind::Contains {
                     if let Some(child) = store.get_node(&e.target_qualified)? {
-                        results.push(node_to_dict(&child));
+                        results.push(node_to_dict(&child, compact));
                     }
                 }
             }
@@ -482,7 +484,7 @@ pub fn query_graph(
             for e in store.get_edges_by_target(&qn)? {
                 if e.kind == EdgeKind::TestedBy {
                     if let Some(t) = store.get_node(&e.source_qualified)? {
-                        results.push(node_to_dict(&t));
+                        results.push(node_to_dict(&t, compact));
                     }
                 }
             }
@@ -494,7 +496,7 @@ pub fn query_graph(
             for prefix in &[format!("test_{name}"), format!("Test{name}")] {
                 for t in store.search_nodes(prefix, 10)? {
                     if !seen.contains(&t.qualified_name) && t.is_test {
-                        results.push(node_to_dict(&t));
+                        results.push(node_to_dict(&t, compact));
                     }
                 }
             }
@@ -503,7 +505,7 @@ pub fn query_graph(
             for e in store.get_edges_by_target(&qn)? {
                 if matches!(e.kind, EdgeKind::Inherits | EdgeKind::Implements) {
                     if let Some(child) = store.get_node(&e.source_qualified)? {
-                        results.push(node_to_dict(&child));
+                        results.push(node_to_dict(&child, compact));
                     }
                     edges_out.push(edge_to_dict(&e));
                 }
@@ -512,7 +514,7 @@ pub fn query_graph(
         QueryPattern::FileSummary => {
             let abs_path = root.join(target).to_string_lossy().into_owned();
             for n in store.get_nodes_by_file(&abs_path)? {
-                results.push(node_to_dict(&n));
+                results.push(node_to_dict(&n, compact));
             }
         }
     }
@@ -540,6 +542,7 @@ pub fn get_review_context(
     max_lines_per_file: usize,
     repo_root: Option<&str>,
     base: &str,
+    compact: bool,
 ) -> Result<Value> {
     let (mut store, root) = get_store(repo_root)?;
     maybe_auto_update(&mut store, &root);
@@ -565,8 +568,8 @@ pub fn get_review_context(
         "changed_files": files,
         "impacted_files": impact.impacted_files,
         "graph": {
-            "changed_nodes": impact.changed_nodes.iter().map(node_to_dict).collect::<Vec<_>>(),
-            "impacted_nodes": impact.impacted_nodes.iter().map(node_to_dict).collect::<Vec<_>>(),
+            "changed_nodes": impact.changed_nodes.iter().map(|n| node_to_dict(n, compact)).collect::<Vec<_>>(),
+            "impacted_nodes": impact.impacted_nodes.iter().map(|n| node_to_dict(n, compact)).collect::<Vec<_>>(),
             "edges": impact.edges.iter().map(edge_to_dict).collect::<Vec<_>>(),
         },
     });
@@ -629,6 +632,7 @@ pub fn semantic_search_nodes(
     kind: Option<&str>,
     limit: usize,
     repo_root: Option<&str>,
+    compact: bool,
 ) -> Result<Value> {
     let (mut store, root) = get_store(repo_root)?;
     maybe_auto_update(&mut store, &root);
@@ -638,7 +642,7 @@ pub fn semantic_search_nodes(
 
     let results: Vec<Value> = if emb_store.available() && emb_store.count()? > 0 {
         search_mode = "semantic";
-        let mut raw = semantic_search(query, &store, &mut emb_store, limit * 2)?;
+        let mut raw = semantic_search(query, &store, &mut emb_store, limit * 2, compact)?;
         if let Some(k) = kind {
             raw.retain(|r| r.get("kind").and_then(|v| v.as_str()) == Some(k));
         }
@@ -658,7 +662,7 @@ pub fn semantic_search_nodes(
             else { 2 }
         });
         nodes.truncate(limit);
-        nodes.iter().map(node_to_dict).collect()
+        nodes.iter().map(|n| node_to_dict(n, compact)).collect()
     };
 
     let kind_suffix = kind.map(|k| format!(" (kind={k})")).unwrap_or_default();
@@ -844,6 +848,7 @@ pub fn hybrid_query(
     query: &str,
     limit: usize,
     repo_root: Option<&str>,
+    compact: bool,
 ) -> Result<Value> {
     if query.trim().is_empty() {
         return Ok(json!({
@@ -877,7 +882,7 @@ pub fn hybrid_query(
     // Semantic ranks (if available)
     if emb_store.available() && emb_store.count().unwrap_or(0) > 0 {
         method = "hybrid_rrf";
-        let semantic_hits = crate::embeddings::semantic_search(query, &store, &mut emb_store, limit * 2)?;
+        let semantic_hits = crate::embeddings::semantic_search(query, &store, &mut emb_store, limit * 2, compact)?;
         for (rank, hit) in semantic_hits.iter().enumerate() {
             if let Some(qn) = hit.get("qualified_name").and_then(|v| v.as_str()) {
                 let score = 1.0 / (RRF_K + rank as f64 + 1.0);
@@ -897,7 +902,7 @@ pub fn hybrid_query(
         .iter()
         .filter_map(|(qn, score)| {
             store.get_node(qn).ok().flatten().map(|node| {
-                let mut d = node_to_dict(&node);
+                let mut d = node_to_dict(&node, compact);
                 d["rrf_score"] = json!(score);
                 d
             })
@@ -995,6 +1000,7 @@ pub fn find_large_functions(
     file_path_pattern: Option<&str>,
     limit: usize,
     repo_root: Option<&str>,
+    compact: bool,
 ) -> Result<Value> {
     let (mut store, root) = get_store(repo_root)?;
     maybe_auto_update(&mut store, &root);
@@ -1011,7 +1017,7 @@ pub fn find_large_functions(
             .strip_prefix(&root)
             .map(|p| p.to_string_lossy().into_owned())
             .unwrap_or_else(|_| n.file_path.clone());
-        let mut d = node_to_dict(n);
+        let mut d = node_to_dict(n, compact);
         d["line_count"] = json!(line_count);
         d["relative_path"] = json!(relative_path);
         d
@@ -1096,7 +1102,7 @@ fn resolve_target_node(
         0 => Ok(ResolveResult::NotFound),
         1 => Ok(ResolveResult::Found(candidates.into_iter().next().unwrap())),
         _ => Ok(ResolveResult::Ambiguous(
-            candidates.iter().map(node_to_dict).collect(),
+            candidates.iter().map(|n| node_to_dict(n, false)).collect(),
         )),
     }
 }
@@ -1327,7 +1333,7 @@ mod tests {
         let (_dir, path) = make_git_repo();
         build_or_update_graph(true, Some(&path), "HEAD").unwrap();
 
-        let result = query_graph("totally_unknown_pattern", "some_target", Some(&path));
+        let result = query_graph("totally_unknown_pattern", "some_target", Some(&path), false);
         assert!(result.is_ok());
         let val = result.unwrap();
         assert_eq!(val["status"], "error");
@@ -1339,7 +1345,7 @@ mod tests {
         let (_dir, path) = make_git_repo();
         build_or_update_graph(true, Some(&path), "HEAD").unwrap();
 
-        let result = query_graph("callers_of", "definitely_not_a_real_function_xyz", Some(&path));
+        let result = query_graph("callers_of", "definitely_not_a_real_function_xyz", Some(&path), false);
         assert!(result.is_ok());
         let val = result.unwrap();
         // Could be "not_found" or "ok" with empty results
@@ -1374,7 +1380,7 @@ mod tests {
         fs::write(dir.path().join("mod.py"), b"def compute(): pass\n").unwrap();
         build_or_update_graph(true, Some(&path), "HEAD").unwrap();
 
-        let result = hybrid_query("", 10, Some(&path));
+        let result = hybrid_query("", 10, Some(&path), false);
         assert!(result.is_ok(), "hybrid_query should succeed: {:?}", result);
         let val = result.unwrap();
         assert_eq!(val["status"], "ok");
@@ -1392,7 +1398,7 @@ mod tests {
         .unwrap();
         build_or_update_graph(true, Some(&path), "HEAD").unwrap();
 
-        let result = hybrid_query("add", 5, Some(&path));
+        let result = hybrid_query("add", 5, Some(&path), false);
         assert!(result.is_ok(), "hybrid_query should succeed: {:?}", result);
         let val = result.unwrap();
         assert_eq!(val["status"], "ok");
@@ -1413,7 +1419,7 @@ mod tests {
         .unwrap();
         build_or_update_graph(true, Some(&path), "HEAD").unwrap();
 
-        let result = hybrid_query("square", 5, Some(&path));
+        let result = hybrid_query("square", 5, Some(&path), false);
         assert!(result.is_ok());
         let val = result.unwrap();
         assert_eq!(val["status"], "ok");

--- a/src/types.rs
+++ b/src/types.rs
@@ -220,20 +220,36 @@ pub struct ImpactResult {
 // ---------------------------------------------------------------------------
 
 /// Convert a GraphNode to a JSON-serializable map.
-pub fn node_to_dict(node: &GraphNode) -> serde_json::Value {
-    serde_json::json!({
-        "name": node.name,
-        "qualified_name": node.qualified_name,
-        "kind": node.kind.as_str(),
-        "file_path": node.file_path,
-        "line_start": node.line_start,
-        "line_end": node.line_end,
-        "language": node.language,
-        "is_test": node.is_test,
-        "docstring": node.docstring,
-        "signature": node.signature,
-        "body_hash": node.body_hash,
-    })
+///
+/// When `compact` is true, only the 7 most useful fields are included,
+/// reducing response size by ~40%. When false, the full 11-field output
+/// is returned unchanged.
+pub fn node_to_dict(node: &GraphNode, compact: bool) -> serde_json::Value {
+    if compact {
+        serde_json::json!({
+            "name": node.name,
+            "qualified_name": node.qualified_name,
+            "kind": node.kind.as_str(),
+            "file_path": node.file_path,
+            "line_start": node.line_start,
+            "line_end": node.line_end,
+            "signature": node.signature,
+        })
+    } else {
+        serde_json::json!({
+            "name": node.name,
+            "qualified_name": node.qualified_name,
+            "kind": node.kind.as_str(),
+            "file_path": node.file_path,
+            "line_start": node.line_start,
+            "line_end": node.line_end,
+            "language": node.language,
+            "is_test": node.is_test,
+            "docstring": node.docstring,
+            "signature": node.signature,
+            "body_hash": node.body_hash,
+        })
+    }
 }
 
 /// Convert a GraphEdge to a JSON-serializable map.

--- a/src/visualization.rs
+++ b/src/visualization.rs
@@ -25,7 +25,7 @@ pub fn export_graph_data(store: &GraphStore) -> Result<Value> {
                 continue;
             }
             seen_qn.insert(gnode.qualified_name.clone());
-            let mut d = node_to_dict(&gnode);
+            let mut d = node_to_dict(&gnode, false);
             // params and return_type are not stored in GraphNode; emit nulls
             // so the JS template can safely reference them.
             if let Some(obj) = d.as_object_mut() {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -123,11 +123,11 @@ fn query_graph_callers_and_callees() {
     build_or_update_graph(true, Some(&root_str), "HEAD").unwrap();
 
     // callees_of "run" should include add and subtract (called inside run)
-    let callees_result = query_graph("callees_of", "run", Some(&root_str)).unwrap();
+    let callees_result = query_graph("callees_of", "run", Some(&root_str), false).unwrap();
     assert_eq!(callees_result["status"], "ok", "callees_of should succeed");
 
     // callers_of "add" should include run (which calls add)
-    let callers_result = query_graph("callers_of", "add", Some(&root_str)).unwrap();
+    let callers_result = query_graph("callers_of", "add", Some(&root_str), false).unwrap();
     assert_eq!(callers_result["status"], "ok", "callers_of should succeed");
 }
 
@@ -305,7 +305,7 @@ fn query_graph_file_summary_returns_nodes() {
     let root_str = dir.path().to_string_lossy().into_owned();
     build_or_update_graph(true, Some(&root_str), "HEAD").unwrap();
 
-    let result = query_graph("file_summary", "utils.py", Some(&root_str)).unwrap();
+    let result = query_graph("file_summary", "utils.py", Some(&root_str), false).unwrap();
     let status = result["status"].as_str().unwrap();
     // file_summary may return "ok" with results, or "ambiguous" when the short
     // name matches multiple recorded paths — both are valid non-error outcomes.
@@ -333,7 +333,7 @@ fn query_graph_imports_of_does_not_error() {
     build_or_update_graph(true, Some(&root_str), "HEAD").unwrap();
 
     // main.py imports from utils — query imports_of main.py
-    let result = query_graph("imports_of", "main.py", Some(&root_str)).unwrap();
+    let result = query_graph("imports_of", "main.py", Some(&root_str), false).unwrap();
     let status = result["status"].as_str().unwrap();
     assert!(
         status == "ok" || status == "not_found" || status == "ambiguous",
@@ -355,7 +355,7 @@ fn query_graph_importers_of_does_not_error() {
     build_or_update_graph(true, Some(&root_str), "HEAD").unwrap();
 
     // utils.py is imported by main.py — query importers_of utils.py
-    let result = query_graph("importers_of", "utils.py", Some(&root_str)).unwrap();
+    let result = query_graph("importers_of", "utils.py", Some(&root_str), false).unwrap();
     let status = result["status"].as_str().unwrap();
     assert!(
         status == "ok" || status == "not_found" || status == "ambiguous",
@@ -376,7 +376,7 @@ fn query_graph_children_of_does_not_error() {
     build_or_update_graph(true, Some(&root_str), "HEAD").unwrap();
 
     // utils.py should contain add and subtract
-    let result = query_graph("children_of", "utils.py", Some(&root_str)).unwrap();
+    let result = query_graph("children_of", "utils.py", Some(&root_str), false).unwrap();
     let status = result["status"].as_str().unwrap();
     assert!(
         status == "ok" || status == "not_found" || status == "ambiguous",
@@ -411,7 +411,7 @@ fn query_graph_tests_for_does_not_error() {
     let root_str = dir.path().to_string_lossy().into_owned();
     build_or_update_graph(true, Some(&root_str), "HEAD").unwrap();
 
-    let result = query_graph("tests_for", "add", Some(&root_str)).unwrap();
+    let result = query_graph("tests_for", "add", Some(&root_str), false).unwrap();
     let status = result["status"].as_str().unwrap();
     assert!(
         status == "ok" || status == "not_found" || status == "ambiguous",
@@ -440,7 +440,7 @@ fn query_graph_inheritors_of_does_not_error() {
     let root_str = dir.path().to_string_lossy().into_owned();
     build_or_update_graph(true, Some(&root_str), "HEAD").unwrap();
 
-    let result = query_graph("inheritors_of", "Animal", Some(&root_str)).unwrap();
+    let result = query_graph("inheritors_of", "Animal", Some(&root_str), false).unwrap();
     let status = result["status"].as_str().unwrap();
     assert!(
         status == "ok" || status == "not_found" || status == "ambiguous",
@@ -460,7 +460,7 @@ fn hybrid_query_returns_ok_with_method_field() {
     let root_str = dir.path().to_string_lossy().into_owned();
     build_or_update_graph(true, Some(&root_str), "HEAD").unwrap();
 
-    let result = hybrid_query("add", 5, Some(&root_str)).unwrap();
+    let result = hybrid_query("add", 5, Some(&root_str), false).unwrap();
     assert_eq!(result["status"], "ok");
     // No embeddings in temp test repos — should fall back to keyword_only
     assert_eq!(
@@ -477,7 +477,7 @@ fn hybrid_query_empty_query_returns_empty() {
     let root_str = dir.path().to_string_lossy().into_owned();
     build_or_update_graph(true, Some(&root_str), "HEAD").unwrap();
 
-    let result = hybrid_query("", 10, Some(&root_str)).unwrap();
+    let result = hybrid_query("", 10, Some(&root_str), false).unwrap();
     assert_eq!(result["status"], "ok");
     assert!(result["results"].as_array().unwrap().is_empty());
 }
@@ -489,7 +489,7 @@ fn hybrid_query_results_include_rrf_score() {
     let root_str = dir.path().to_string_lossy().into_owned();
     build_or_update_graph(true, Some(&root_str), "HEAD").unwrap();
 
-    let result = hybrid_query("subtract", 5, Some(&root_str)).unwrap();
+    let result = hybrid_query("subtract", 5, Some(&root_str), false).unwrap();
     assert_eq!(result["status"], "ok");
     let arr = result["results"].as_array().unwrap();
     if !arr.is_empty() {


### PR DESCRIPTION
## Summary

- Adds `compact: bool` parameter to 5 MCP tool param structs (`ImpactRadiusParams`, `QueryGraphParams`, `ReviewContextParams`, `SemanticSearchParams`, `LargeFunctionsParams`)
- When `compact=true`, `node_to_dict` returns 7 fields instead of 11 (`name`, `qualified_name`, `kind`, `file_path`, `line_start`, `line_end`, `signature`), stripping `language`, `is_test`, `docstring`, `body_hash`
- Reduces response token count by ~40% for callers that don't need the full node representation
- `resolve_target_node` (disambiguation) is pinned to `compact=false` so candidates always carry full detail
- `visualization.rs` is pinned to `compact=false` (JS template needs all fields)

## Test plan

- [ ] `cargo test --release` — all 18 tests pass
- [ ] `cargo build --features embeddings-fastembed` — compiles cleanly
- [ ] Verify MCP tool accepts `compact: true` without error (schema change is additive, defaults to `false`)
- [ ] Verify `compact: false` (default) output is identical to pre-change output

🤖 Generated with [Claude Code](https://claude.com/claude-code)