### PR TITLE
test: add insta snapshot tests for MCP tool responses

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,6 +117,7 @@ chrono = { version = "0.4", features = ["serde"] }
 assert_cmd = "2"
 predicates = "3"
 criterion = { version = "0.8", features = ["html_reports"] }
+insta = { version = "1", features = ["json", "redactions"] }
 
 [[bench]]
 name = "benchmarks"

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -7,7 +7,8 @@ use code_review_graph::graph::GraphStore;
 use code_review_graph::incremental::{full_build, get_db_path, incremental_update};
 use code_review_graph::parser::CodeParser;
 use code_review_graph::tools::{
-    build_or_update_graph, hybrid_query, list_graph_stats, measure_token_reduction, query_graph,
+    build_or_update_graph, find_large_functions, get_impact_radius, hybrid_query, list_graph_stats,
+    measure_token_reduction, query_graph, semantic_search_nodes, trace_call_chain,
 };
 use tempfile::TempDir;
 
@@ -545,4 +546,159 @@ fn measure_token_reduction_naive_bytes_exceeds_context_for_changed_files() {
         naive >= context,
         "naive_bytes ({naive}) should be >= context_bytes ({context}) when reviewing a subset of files"
     );
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot tests (insta)
+// ---------------------------------------------------------------------------
+
+/// Walk a JSON value and replace any string that contains the temp dir path
+/// (in any platform path format) with `[path]`.
+fn redact_temp_paths(val: &mut serde_json::Value, temp_dir: &str) {
+    // Strip the Windows extended-length prefix (//?/) and normalise separators
+    // so the match works regardless of how the path was recorded.
+    let norm = temp_dir.replace('\\', "/");
+    let plain = norm.trim_start_matches("//?/");
+
+    match val {
+        serde_json::Value::String(s) => {
+            // Normalise both sides to forward slashes and strip the Windows
+            // extended-length prefix (//?/) before matching.
+            let s_plain = s.replace('\\', "/");
+            let s_plain = s_plain.trim_start_matches("//?/");
+            if s_plain.contains(plain) {
+                *s = "[path]".to_string();
+            }
+        }
+        serde_json::Value::Array(arr) => {
+            for item in arr.iter_mut() {
+                redact_temp_paths(item, temp_dir);
+            }
+        }
+        serde_json::Value::Object(map) => {
+            for v in map.values_mut() {
+                redact_temp_paths(v, temp_dir);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Sort an array-of-objects field by the given key, if it exists.
+fn sort_array_by_key(val: &mut serde_json::Value, array_ptr: &str, key: &str) {
+    if let Some(arr) = val.pointer_mut(array_ptr).and_then(|v| v.as_array_mut()) {
+        arr.sort_by(|a, b| {
+            let ka = a.get(key).and_then(|v| v.as_str()).unwrap_or("");
+            let kb = b.get(key).and_then(|v| v.as_str()).unwrap_or("");
+            ka.cmp(kb)
+        });
+    }
+}
+
+#[test]
+fn snapshot_list_graph_stats() {
+    if !grammars_available() { return; }
+    let dir = setup_test_repo();
+    let root_str = dir.path().to_string_lossy().into_owned();
+    build_or_update_graph(true, Some(&root_str), "HEAD").unwrap();
+
+    let mut result = list_graph_stats(Some(&root_str)).unwrap();
+    // languages order is non-deterministic — sort for stable snapshot
+    if let Some(langs) = result.get_mut("languages").and_then(|v| v.as_array_mut()) {
+        langs.sort_by(|a, b| a.as_str().cmp(&b.as_str()));
+    }
+    insta::assert_json_snapshot!(result, {
+        ".last_updated" => "[timestamp]",
+        ".summary" => "[summary]",
+    });
+}
+
+#[test]
+fn snapshot_query_graph_children_of() {
+    if !grammars_available() { return; }
+    let dir = setup_test_repo();
+    let root_str = dir.path().to_string_lossy().into_owned();
+    build_or_update_graph(true, Some(&root_str), "HEAD").unwrap();
+
+    let mut result = query_graph("children_of", "utils.py", Some(&root_str), false).unwrap();
+    let temp_dir = dir.path().to_string_lossy().into_owned();
+    redact_temp_paths(&mut result, &temp_dir);
+    sort_array_by_key(&mut result, "/results", "name");
+    sort_array_by_key(&mut result, "/candidates", "name");
+    insta::assert_json_snapshot!(result, {
+        ".summary" => "[summary]",
+    });
+}
+
+#[test]
+fn snapshot_find_large_functions() {
+    if !grammars_available() { return; }
+    let dir = setup_test_repo();
+    let root_str = dir.path().to_string_lossy().into_owned();
+    build_or_update_graph(true, Some(&root_str), "HEAD").unwrap();
+
+    // min_lines=1 to capture the small functions in the test repo
+    let mut result = find_large_functions(1, None, None, 20, Some(&root_str), true).unwrap();
+    let temp_dir = dir.path().to_string_lossy().into_owned();
+    redact_temp_paths(&mut result, &temp_dir);
+    sort_array_by_key(&mut result, "/results", "name");
+    insta::assert_json_snapshot!(result, {
+        ".summary" => "[summary]",
+    });
+}
+
+#[test]
+fn snapshot_get_impact_radius() {
+    if !grammars_available() { return; }
+    let dir = setup_test_repo();
+    let root_str = dir.path().to_string_lossy().into_owned();
+    build_or_update_graph(true, Some(&root_str), "HEAD").unwrap();
+
+    let mut result = get_impact_radius(
+        Some(vec!["utils.py".to_string()]),
+        3,
+        Some(&root_str),
+        "HEAD",
+        true,
+    ).unwrap();
+    let temp_dir = dir.path().to_string_lossy().into_owned();
+    redact_temp_paths(&mut result, &temp_dir);
+    sort_array_by_key(&mut result, "/changed_nodes", "name");
+    sort_array_by_key(&mut result, "/impacted_nodes", "name");
+    insta::assert_json_snapshot!(result, {
+        ".summary" => "[summary]",
+    });
+}
+
+#[test]
+fn snapshot_trace_call_chain() {
+    if !grammars_available() { return; }
+    let dir = setup_test_repo();
+    let root_str = dir.path().to_string_lossy().into_owned();
+    build_or_update_graph(true, Some(&root_str), "HEAD").unwrap();
+
+    // run calls add — trace the chain
+    let mut result = trace_call_chain("run", "add", 5, false, Some(&root_str)).unwrap();
+    let temp_dir = dir.path().to_string_lossy().into_owned();
+    redact_temp_paths(&mut result, &temp_dir);
+    insta::assert_json_snapshot!(result, {
+        ".summary" => "[summary]",
+    });
+}
+
+#[test]
+fn snapshot_semantic_search_nodes() {
+    if !grammars_available() { return; }
+    let dir = setup_test_repo();
+    let root_str = dir.path().to_string_lossy().into_owned();
+    build_or_update_graph(true, Some(&root_str), "HEAD").unwrap();
+
+    let mut result = semantic_search_nodes("add function", None, 5, Some(&root_str), true).unwrap();
+    let temp_dir = dir.path().to_string_lossy().into_owned();
+    redact_temp_paths(&mut result, &temp_dir);
+    sort_array_by_key(&mut result, "/results", "name");
+    insta::assert_json_snapshot!(result, {
+        ".results[].similarity" => "[score]",
+        ".summary" => "[summary]",
+    });
 }

--- a/tests/snapshots/integration__snapshot_find_large_functions.snap
+++ b/tests/snapshots/integration__snapshot_find_large_functions.snap
@@ -1,0 +1,100 @@
+---
+source: tests/integration.rs
+expression: result
+---
+{
+  "min_lines": 1,
+  "results": [
+    {
+      "file_path": "service.ts",
+      "kind": "File",
+      "line_count": 9,
+      "line_end": 9,
+      "line_start": 1,
+      "name": "[path]",
+      "qualified_name": "service.ts",
+      "relative_path": "[path]",
+      "signature": ""
+    },
+    {
+      "file_path": "main.py",
+      "kind": "File",
+      "line_count": 8,
+      "line_end": 8,
+      "line_start": 1,
+      "name": "[path]",
+      "qualified_name": "main.py",
+      "relative_path": "[path]",
+      "signature": ""
+    },
+    {
+      "file_path": "utils.py",
+      "kind": "File",
+      "line_count": 7,
+      "line_end": 7,
+      "line_start": 1,
+      "name": "[path]",
+      "qualified_name": "utils.py",
+      "relative_path": "[path]",
+      "signature": ""
+    },
+    {
+      "file_path": "utils.py",
+      "kind": "Function",
+      "line_count": 2,
+      "line_end": 3,
+      "line_start": 2,
+      "name": "add",
+      "qualified_name": "utils.py::add",
+      "relative_path": "[path]",
+      "signature": "(a, b)"
+    },
+    {
+      "file_path": "service.ts",
+      "kind": "Function",
+      "line_count": 3,
+      "line_end": 8,
+      "line_start": 6,
+      "name": "farewell",
+      "qualified_name": "service.ts::farewell",
+      "relative_path": "[path]",
+      "signature": "(name: string) -> : string"
+    },
+    {
+      "file_path": "service.ts",
+      "kind": "Function",
+      "line_count": 3,
+      "line_end": 4,
+      "line_start": 2,
+      "name": "greet",
+      "qualified_name": "service.ts::greet",
+      "relative_path": "[path]",
+      "signature": "(name: string) -> : string"
+    },
+    {
+      "file_path": "main.py",
+      "kind": "Function",
+      "line_count": 4,
+      "line_end": 7,
+      "line_start": 4,
+      "name": "run",
+      "qualified_name": "main.py::run",
+      "relative_path": "[path]",
+      "signature": "()"
+    },
+    {
+      "file_path": "utils.py",
+      "kind": "Function",
+      "line_count": 2,
+      "line_end": 6,
+      "line_start": 5,
+      "name": "subtract",
+      "qualified_name": "utils.py::subtract",
+      "relative_path": "[path]",
+      "signature": "(a, b)"
+    }
+  ],
+  "status": "ok",
+  "summary": "[summary]",
+  "total_found": 8
+}

--- a/tests/snapshots/integration__snapshot_get_impact_radius.snap
+++ b/tests/snapshots/integration__snapshot_get_impact_radius.snap
@@ -1,0 +1,62 @@
+---
+source: tests/integration.rs
+expression: result
+---
+{
+  "algorithm": "personalized_pagerank",
+  "changed_files": [
+    "utils.py"
+  ],
+  "changed_nodes": [
+    {
+      "file_path": "utils.py",
+      "kind": "File",
+      "line_end": 7,
+      "line_start": 1,
+      "name": "[path]",
+      "qualified_name": "utils.py",
+      "signature": ""
+    },
+    {
+      "file_path": "utils.py",
+      "kind": "Function",
+      "line_end": 3,
+      "line_start": 2,
+      "name": "add",
+      "qualified_name": "utils.py::add",
+      "signature": "(a, b)"
+    },
+    {
+      "file_path": "utils.py",
+      "kind": "Function",
+      "line_end": 6,
+      "line_start": 5,
+      "name": "subtract",
+      "qualified_name": "utils.py::subtract",
+      "signature": "(a, b)"
+    }
+  ],
+  "edges": [
+    {
+      "file_path": "[path]",
+      "kind": "CONTAINS",
+      "line": 0,
+      "source_qualified": "[path]",
+      "target_qualified": "[path]"
+    },
+    {
+      "file_path": "[path]",
+      "kind": "CONTAINS",
+      "line": 0,
+      "source_qualified": "[path]",
+      "target_qualified": "[path]"
+    }
+  ],
+  "impact_scores": [],
+  "impacted_files": [],
+  "impacted_nodes": [],
+  "status": "ok",
+  "summary": "[summary]",
+  "total_impacted": 0,
+  "truncated": false
+}

--- a/tests/snapshots/integration__snapshot_list_graph_stats.snap
+++ b/tests/snapshots/integration__snapshot_list_graph_stats.snap
@@ -1,0 +1,24 @@
+---
+source: tests/integration.rs
+expression: result
+---
+{
+  "edges_by_kind": {
+    "Contains": 5
+  },
+  "embeddings_count": 0,
+  "files_count": 3,
+  "languages": [
+    "python",
+    "typescript"
+  ],
+  "last_updated": "[timestamp]",
+  "nodes_by_kind": {
+    "File": 3,
+    "Function": 5
+  },
+  "status": "ok",
+  "summary": "[summary]",
+  "total_edges": 5,
+  "total_nodes": 8
+}

--- a/tests/snapshots/integration__snapshot_query_graph_children_of.snap
+++ b/tests/snapshots/integration__snapshot_query_graph_children_of.snap
@@ -1,0 +1,49 @@
+---
+source: tests/integration.rs
+expression: result
+---
+{
+  "candidates": [
+    {
+      "body_hash": "16ce0c541a7c88341af2bf4b18327c3b0885e924b39910d01ef237752d323a84",
+      "docstring": "",
+      "file_path": "[path]",
+      "is_test": false,
+      "kind": "File",
+      "language": "python",
+      "line_end": 7,
+      "line_start": 1,
+      "name": "[path]",
+      "qualified_name": "[path]",
+      "signature": ""
+    },
+    {
+      "body_hash": "8f75a68646c879fd0cff5c02708c010fb1c01d67ef9930d4e419106feb7897aa",
+      "docstring": "",
+      "file_path": "[path]",
+      "is_test": false,
+      "kind": "Function",
+      "language": "python",
+      "line_end": 3,
+      "line_start": 2,
+      "name": "add",
+      "qualified_name": "[path]",
+      "signature": "(a, b)"
+    },
+    {
+      "body_hash": "58503bef65c62ed04279dcca0a154139c1e574aea5c321413eec60cab10e3e76",
+      "docstring": "",
+      "file_path": "[path]",
+      "is_test": false,
+      "kind": "Function",
+      "language": "python",
+      "line_end": 6,
+      "line_start": 5,
+      "name": "subtract",
+      "qualified_name": "[path]",
+      "signature": "(a, b)"
+    }
+  ],
+  "status": "ambiguous",
+  "summary": "[summary]"
+}

--- a/tests/snapshots/integration__snapshot_semantic_search_nodes.snap
+++ b/tests/snapshots/integration__snapshot_semantic_search_nodes.snap
@@ -1,0 +1,11 @@
+---
+source: tests/integration.rs
+expression: result
+---
+{
+  "query": "add function",
+  "results": [],
+  "search_mode": "keyword",
+  "status": "ok",
+  "summary": "[summary]"
+}

--- a/tests/snapshots/integration__snapshot_trace_call_chain.snap
+++ b/tests/snapshots/integration__snapshot_trace_call_chain.snap
@@ -1,0 +1,8 @@
+---
+source: tests/integration.rs
+expression: result
+---
+{
+  "status": "no_path",
+  "summary": "[summary]"
+}


### PR DESCRIPTION
## Summary

- Add `insta` (v1, json + redactions features) to `[dev-dependencies]`
- Add 6 snapshot tests covering key MCP tool JSON shapes: `list_graph_stats`, `query_graph` (children_of), `find_large_functions`, `get_impact_radius`, `trace_call_chain`, `semantic_search_nodes`
- Add `redact_temp_paths` helper that normalises Windows UNC paths (`//?/`) and forward/backslash variants before matching, so temp-dir paths are consistently replaced with `[path]`
- Add `sort_array_by_key` helper to sort arrays-of-objects by a named field, making node-array ordering deterministic across runs
- Volatile fields (`last_updated`, `summary`, `similarity`) are redacted via insta selectors

## Test plan

- [ ] `cargo test --test integration snapshot` — all 6 snapshot tests pass
- [ ] Run twice in succession — results are identical (determinism check)
- [ ] `cargo build --release` — compiles cleanly