### PR TITLE
refactor: migrate from log+env_logger to tracing+tracing-subscriber

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,8 +107,8 @@ dirs = "6"
 
 # Utilities
 regex = "1"
-log = "0.4"
-env_logger = "0.11"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 thiserror = "2"
 anyhow = "1"
 chrono = { version = "0.4", features = ["serde"] }

--- a/src/embeddings.rs
+++ b/src/embeddings.rs
@@ -326,7 +326,7 @@ impl FastEmbedProvider {
         #[cfg(feature = "gpu-directml")]
         {
             use ort::execution_providers::DirectMLExecutionProvider;
-            log::info!("DirectML GPU acceleration enabled — trying GPU first, CPU fallback");
+            tracing::info!("DirectML GPU acceleration enabled — trying GPU first, CPU fallback");
             init = init.with_execution_providers(vec![
                 DirectMLExecutionProvider::default().build(),
             ]);
@@ -540,29 +540,29 @@ fn detect_provider() -> Option<Box<dyn EmbeddingProvider>> {
                 let api_key = get("OPENAI_API_KEY", "openai-api-key")?;
                 let model = get("EMBEDDING_MODEL", "embedding-model")
                     .unwrap_or_else(|| "text-embedding-3-small".to_string());
-                log::info!("Embedding provider: OpenAI (model={})", model);
+                tracing::info!("Embedding provider: OpenAI (model={})", model);
                 return Some(Box::new(OpenAiProvider::new(api_key, model)));
             }
             "voyage" => {
                 let api_key = get("VOYAGE_API_KEY", "voyage-api-key")?;
                 let model = get("EMBEDDING_MODEL", "embedding-model")
                     .unwrap_or_else(|| "voyage-code-3".to_string());
-                log::info!("Embedding provider: Voyage AI (model={})", model);
+                tracing::info!("Embedding provider: Voyage AI (model={})", model);
                 return Some(Box::new(VoyageProvider::new(api_key, model)));
             }
             "gemini" => {
                 let api_key = get("GEMINI_API_KEY", "gemini-api-key")?;
                 let model = get("EMBEDDING_MODEL", "embedding-model")
                     .unwrap_or_else(|| "text-embedding-004".to_string());
-                log::info!("Embedding provider: Gemini (model={})", model);
+                tracing::info!("Embedding provider: Gemini (model={})", model);
                 return Some(Box::new(GeminiProvider::new(api_key, model)));
             }
             "none" | "disabled" => {
-                log::info!("Embeddings explicitly disabled via embedding-provider=none");
+                tracing::info!("Embeddings explicitly disabled via embedding-provider=none");
                 return None;
             }
             other => {
-                log::warn!("Unknown embedding-provider='{}'; falling back to local", other);
+                tracing::warn!("Unknown embedding-provider='{}'; falling back to local", other);
             }
         }
     }
@@ -572,11 +572,11 @@ fn detect_provider() -> Option<Box<dyn EmbeddingProvider>> {
     {
         match FastEmbedProvider::new() {
             Ok(p) => {
-                log::info!("Embedding provider: fastembed-jina-v2-code (local, free)");
+                tracing::info!("Embedding provider: fastembed-jina-v2-code (local, free)");
                 return Some(Box::new(p));
             }
             Err(e) => {
-                log::warn!("fastembed init failed: {}; trying candle fallback", e);
+                tracing::warn!("fastembed init failed: {}; trying candle fallback", e);
             }
         }
     }
@@ -586,11 +586,11 @@ fn detect_provider() -> Option<Box<dyn EmbeddingProvider>> {
     {
         match CandleProvider::new() {
             Ok(p) => {
-                log::info!("Embedding provider: candle-minilm (all-MiniLM-L6-v2, local, free)");
+                tracing::info!("Embedding provider: candle-minilm (all-MiniLM-L6-v2, local, free)");
                 return Some(Box::new(p));
             }
             Err(e) => {
-                log::warn!("Local embedding provider unavailable: {}; embeddings disabled", e);
+                tracing::warn!("Local embedding provider unavailable: {}; embeddings disabled", e);
             }
         }
     }
@@ -618,7 +618,7 @@ impl EmbeddingStore {
             match load_embedding_data(store_path) {
                 Ok(d) => d,
                 Err(e) => {
-                    log::warn!(
+                    tracing::warn!(
                         "Could not load embeddings from {}: {} — starting empty",
                         store_path.display(),
                         e
@@ -676,7 +676,7 @@ impl EmbeddingStore {
             .collect();
         let removed = stale_keys.len();
         if removed > 0 {
-            log::info!("Embedding GC: removing {} stale vector(s)", removed);
+            tracing::info!("Embedding GC: removing {} stale vector(s)", removed);
             for k in &stale_keys {
                 self.data.vectors.remove(k);
             }
@@ -875,7 +875,7 @@ pub fn semantic_search(
                 return nodes_from_scored(scored, store, compact, repo_root);
             }
             Err(e) => {
-                log::warn!("HNSW index build failed ({}); falling back to linear scan", e);
+                tracing::warn!("HNSW index build failed ({}); falling back to linear scan", e);
             }
         }
     }
@@ -915,7 +915,7 @@ fn nodes_from_scored(
 
 fn cosine_similarity(a: &[f32], b: &[f32]) -> f64 {
     if a.len() != b.len() {
-        log::error!("cosine_similarity: dimension mismatch {} vs {}", a.len(), b.len());
+        tracing::error!("cosine_similarity: dimension mismatch {} vs {}", a.len(), b.len());
         return 0.0;
     }
     let dot: f64 = a.iter().zip(b).map(|(x, y)| (*x as f64) * (*y as f64)).sum();

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -89,7 +89,7 @@ impl GraphStore {
             match load(db_path) {
                 Ok(d) => d,
                 Err(e) => {
-                    log::warn!(
+                    tracing::warn!(
                         "Could not load graph from {}: {} — starting empty",
                         db_path.display(),
                         e

--- a/src/incremental.rs
+++ b/src/incremental.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 
 use chrono::Utc;
 use indicatif::{ProgressBar, ProgressStyle};
-use log::{error, info, warn};
+use tracing::{error, info, warn};
 use notify::RecursiveMode;
 use notify_debouncer_mini::{new_debouncer, DebounceEventResult};
 use rayon::prelude::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,7 +102,12 @@ enum ConfigAction {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    env_logger::init();
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::from_default_env()
+                .add_directive(tracing::Level::WARN.into()),
+        )
+        .init();
     let cli = Cli::parse();
 
     match cli.command {

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -38,7 +38,7 @@ pub fn save_blob<T: Serialize>(data: &T, path: &Path, label: &str) -> Result<()>
     tmp.persist(path)
         .map_err(|e| CrgError::Io(e.error))?;
 
-    log::debug!("{label}: saved {} bytes to {}", compressed.len() + 8, path.display());
+    tracing::debug!("{label}: saved {} bytes to {}", compressed.len() + 8, path.display());
     Ok(())
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -233,6 +233,7 @@ impl CodeReviewServer {
     /// Call this first to initialize the graph, or after making changes.
     /// By default performs an incremental update (only changed files).
     /// Set full_rebuild=True to re-parse every file.
+    #[tracing::instrument(skip(self))]
     #[tool(name = "build_or_update_graph")]
     async fn build_or_update_graph_tool(
         &self,
@@ -256,6 +257,7 @@ impl CodeReviewServer {
     /// classes, and files are affected. Use during code review to understand
     /// what a change impacts. Pass changed file paths, or let it auto-detect
     /// from git diff. Follow up with Read tool on impacted files.
+    #[tracing::instrument(skip(self))]
     #[tool(name = "get_impact_radius")]
     async fn get_impact_radius_tool(
         &self,
@@ -283,6 +285,7 @@ impl CodeReviewServer {
     /// Use callers_of/callees_of to navigate between functions instead of
     /// running grep in bash. After finding connected functions, use the
     /// Read tool to examine their logic.
+    #[tracing::instrument(skip(self))]
     #[tool(name = "query_graph")]
     async fn query_graph_tool(
         &self,
@@ -307,6 +310,7 @@ impl CodeReviewServer {
     ///
     /// Combines impact analysis with source snippets and review guidance.
     /// Use this for comprehensive code reviews.
+    #[tracing::instrument(skip(self))]
     #[tool(name = "get_review_context")]
     async fn get_review_context_tool(
         &self,
@@ -338,6 +342,7 @@ impl CodeReviewServer {
     /// Returns ranked results with similarity scores. After finding targets,
     /// use the Read tool (not bash cat) to examine their source code.
     /// Always pass compact: true to reduce response size.
+    #[tracing::instrument(skip(self))]
     #[tool(name = "semantic_search_nodes")]
     async fn semantic_search_nodes_tool(
         &self,
@@ -363,6 +368,7 @@ impl CodeReviewServer {
     ///
     /// Shows total nodes, edges, languages, files, and last update time.
     /// Useful for checking if the graph is built and up to date.
+    #[tracing::instrument(skip(self))]
     #[tool(name = "list_graph_stats")]
     async fn list_graph_stats_tool(
         &self,
@@ -383,6 +389,7 @@ impl CodeReviewServer {
     /// Uses the all-MiniLM-L6-v2 model (384-dim vectors).
     /// Only computes embeddings for nodes that don't already have them.
     /// After running this, semantic_search_nodes_tool uses vector similarity.
+    #[tracing::instrument(skip(self))]
     #[tool(name = "embed_graph")]
     async fn embed_graph_tool(
         &self,
@@ -403,6 +410,7 @@ impl CodeReviewServer {
     /// Returns only the requested section content for minimal token usage.
     /// Available sections: usage, review-delta, review-pr, commands, legal,
     /// watch, embeddings, languages, troubleshooting.
+    #[tracing::instrument(skip(self))]
     #[tool(name = "get_docs_section")]
     async fn get_docs_section_tool(
         &self,
@@ -422,6 +430,7 @@ impl CodeReviewServer {
     /// business logic concentrates and finding likely bug locations.
     /// Use for decomposition audits and code quality checks.
     /// Results ordered by size, largest first.
+    #[tracing::instrument(skip(self))]
     #[tool(name = "find_large_functions")]
     async fn find_large_functions_tool(
         &self,
@@ -452,6 +461,7 @@ impl CodeReviewServer {
     /// files one-by-one to manually follow call chains. Try this BEFORE
     /// reading multiple files — it often answers "how does A reach B?"
     /// in one call. Tries callee direction first, then caller direction.
+    #[tracing::instrument(skip(self))]
     #[tool(name = "trace_call_chain")]
     async fn trace_call_chain_tool(
         &self,
@@ -576,7 +586,7 @@ fn run_background_watcher(repo_root: PathBuf) -> crate::error::Result<()> {
         .watch(&repo_root, RecursiveMode::Recursive)
         .map_err(|e| crate::error::CrgError::Other(e.to_string()))?;
 
-    log::info!(
+    tracing::info!(
         "Background watcher active — watching {}",
         repo_root.display()
     );
@@ -585,7 +595,7 @@ fn run_background_watcher(repo_root: PathBuf) -> crate::error::Result<()> {
         let events = match result {
             Ok(evts) => evts,
             Err(e) => {
-                log::error!("Watcher error: {:?}", e);
+                tracing::error!("Watcher error: {:?}", e);
                 continue;
             }
         };
@@ -623,7 +633,7 @@ fn run_background_watcher(repo_root: PathBuf) -> crate::error::Result<()> {
         let mut store = match GraphStore::new(&db_path) {
             Ok(s) => s,
             Err(e) => {
-                log::error!("Background watcher: could not open store: {}", e);
+                tracing::error!("Background watcher: could not open store: {}", e);
                 continue;
             }
         };
@@ -631,13 +641,13 @@ fn run_background_watcher(repo_root: PathBuf) -> crate::error::Result<()> {
         for path in &paths_to_remove {
             let abs_str = path.to_string_lossy().into_owned();
             if let Err(e) = store.remove_file_data(&abs_str) {
-                log::error!("Watcher remove {}: {}", abs_str, e);
+                tracing::error!("Watcher remove {}: {}", abs_str, e);
             } else {
                 let rel = path
                     .strip_prefix(&repo_root)
                     .map(|p| p.display().to_string())
                     .unwrap_or_else(|_| abs_str.clone());
-                log::info!("Watcher removed: {}", rel);
+                tracing::info!("Watcher removed: {}", rel);
             }
         }
 
@@ -659,7 +669,7 @@ fn run_background_watcher(repo_root: PathBuf) -> crate::error::Result<()> {
                         .strip_prefix(&repo_root)
                         .map(|p| p.display().to_string())
                         .unwrap_or_else(|_| abs_str.clone());
-                    log::info!("Watcher updated: {} ({} nodes, {} edges)", rel, n, e);
+                    tracing::info!("Watcher updated: {} ({} nodes, {} edges)", rel, n, e);
 
                     // Re-parse dependents so cross-file edges stay fresh.
                     let deps = find_dependents(&store, &abs_str).unwrap_or_default();
@@ -670,15 +680,15 @@ fn run_background_watcher(repo_root: PathBuf) -> crate::error::Result<()> {
                         processed.insert(dep_path.clone());
                         let dep = std::path::PathBuf::from(dep_path);
                         match watcher_parse_and_store(&parser, &mut store, &dep) {
-                            Ok(Some((dn, de))) => log::debug!(
+                            Ok(Some((dn, de))) => tracing::debug!(
                                 "Watcher re-parsed dependent: {} ({} nodes, {} edges)",
                                 dep_path, dn, de
                             ),
-                            Ok(None) => log::debug!(
+                            Ok(None) => tracing::debug!(
                                 "Watcher dependent unchanged (hash match): {}",
                                 dep_path
                             ),
-                            Err(e) => log::warn!("Watcher dependent {}: {}", dep_path, e),
+                            Err(e) => tracing::warn!("Watcher dependent {}: {}", dep_path, e),
                         }
                     }
                 }
@@ -687,18 +697,18 @@ fn run_background_watcher(repo_root: PathBuf) -> crate::error::Result<()> {
                         .strip_prefix(&repo_root)
                         .map(|p| p.display().to_string())
                         .unwrap_or_else(|_| abs_str.clone());
-                    log::debug!("Watcher skipped (hash unchanged): {}", rel);
+                    tracing::debug!("Watcher skipped (hash unchanged): {}", rel);
                 }
-                Err(err) => log::error!("Watcher {}", err),
+                Err(err) => tracing::error!("Watcher {}", err),
             }
         }
 
         if let Err(e) = store.commit() {
-            log::error!("Watcher commit error: {}", e);
+            tracing::error!("Watcher commit error: {}", e);
         }
     }
 
-    log::info!("Background watcher stopped.");
+    tracing::info!("Background watcher stopped.");
     Ok(())
 }
 
@@ -712,11 +722,11 @@ pub async fn run_server(repo_root: Option<String>) -> crate::error::Result<()> {
         let watcher_root = root.clone();
         std::thread::spawn(move || {
             if let Err(e) = run_background_watcher(watcher_root) {
-                log::error!("Background watcher error: {}", e);
+                tracing::error!("Background watcher error: {}", e);
             }
         });
     } else {
-        log::info!("No repo root detected, background watcher disabled");
+        tracing::info!("No repo root detected, background watcher disabled");
     }
 
     let server = CodeReviewServer::new(repo_root);

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -164,7 +164,7 @@ fn maybe_auto_update(store: &mut GraphStore, repo_root: &Path) {
     }
     // Only update if there are actually changed source files not yet in the graph
     if let Err(e) = crate::incremental::incremental_update(repo_root, store, "HEAD", Some(source_changed)) {
-        log::warn!("auto-update failed: {}", e);
+        tracing::warn!("auto-update failed: {}", e);
     }
 }
 


### PR DESCRIPTION
## Summary
- Swap `log = "0.4"` + `env_logger = "0.11"` for `tracing = "0.1"` + `tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }` in Cargo.toml
- Replace `env_logger::init()` in `main.rs` with `tracing_subscriber::fmt()` + `EnvFilter` (default WARN, overridable via `RUST_LOG`)
- Mechanically replace all `log::X!` macro calls across 5 source files (32 total: `embeddings.rs` ×14, `server.rs` ×15, `graph.rs` ×1, `persistence.rs` ×1, `tools.rs` ×1)
- Add `#[tracing::instrument(skip(self))]` to all 10 MCP tool handler methods in `server.rs` for per-request span correlation

## Test plan
- [ ] `cargo test --no-default-features` passes (18/18 tests green — verified locally)
- [ ] `cargo build --release --no-default-features` compiles clean
- [ ] Set `RUST_LOG=debug` and run `code-review-graph serve` — verify tracing output appears on stderr
- [ ] Set `RUST_LOG=info` and trigger a tool call — verify span events appear with handler name

## Notes
- The `ort-sys` build error when compiling with `embeddings-fastembed` feature is pre-existing (TLS config API mismatch in `ort-sys v2.0.0-rc.12`) and unrelated to this change
- `incremental.rs` uses `use tracing::{error, info, warn}` (idiomatic for a file with many logging calls); all other files use `tracing::X!` path syntax directly — both are correct