### PR TITLE
test: add cargo-fuzz target for parser

### DIFF
--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,3 @@
+target/
+corpus/
+artifacts/

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "code-review-graph-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+arbitrary = { version = "1", features = ["derive"] }
+
+[dependencies.code-review-graph]
+path = ".."
+
+[[bin]]
+name = "fuzz_parse_bytes"
+path = "fuzz_targets/fuzz_parse_bytes.rs"
+test = false
+doc = false

--- a/fuzz/build.rs
+++ b/fuzz/build.rs
@@ -1,0 +1,9 @@
+fn main() {
+    // On MSVC Windows, the libfuzzer static archive contains main() but the
+    // MSVC linker won't pull it in automatically because no Rust code references
+    // it directly. Force-include it via /INCLUDE and tell the linker the entry.
+    if std::env::var("CARGO_CFG_TARGET_ENV").as_deref() == Ok("msvc") {
+        println!("cargo:rustc-link-arg=/INCLUDE:main");
+        println!("cargo:rustc-link-arg=/ENTRY:mainCRTStartup");
+    }
+}

--- a/fuzz/fuzz_targets/fuzz_parse_bytes.rs
+++ b/fuzz/fuzz_targets/fuzz_parse_bytes.rs
@@ -1,0 +1,25 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+use std::path::Path;
+
+#[derive(Arbitrary, Debug)]
+struct FuzzInput {
+    source: Vec<u8>,
+    extension_idx: u8,
+}
+
+const EXTENSIONS: &[&str] = &[
+    "py", "ts", "tsx", "js", "jsx", "rs", "go", "java",
+    "c", "cpp", "cs", "rb", "php", "kt", "swift", "vue",
+    "unknown",
+];
+
+fuzz_target!(|input: FuzzInput| {
+    let ext = EXTENSIONS[input.extension_idx as usize % EXTENSIONS.len()];
+    let path = Path::new("fuzz_input").with_extension(ext);
+    let parser = code_review_graph::parser::CodeParser::new();
+    // parse_bytes should never panic — any panic is a bug
+    let _ = parser.parse_bytes(&path, &input.source);
+});


### PR DESCRIPTION
## Summary

- Adds `fuzz/` crate with a `fuzz_parse_bytes` target that feeds arbitrary bytes and file extension indices to `CodeParser::parse_bytes()`, catching any panics as bugs
- Includes a `build.rs` MSVC linker workaround so `cargo build --manifest-path fuzz/Cargo.toml` compiles on Windows without sanitizer toolchain
- Adds `fuzz/.gitignore` to exclude `target/`, `corpus/`, and `artifacts/`

## Technical note on MSVC workaround

libfuzzer's `main()` is defined in `FuzzerMain.cpp` inside the static archive, but MSVC `link.exe` won't pull unreferenced symbols from static libs. `build.rs` emits `/INCLUDE:main` (forces the symbol to be pulled) and `/ENTRY:mainCRTStartup` (sets the CRT startup entry) for MSVC targets only.

## Test plan

- [ ] `cargo build --manifest-path fuzz/Cargo.toml` compiles without errors
- [ ] `cargo fuzz run fuzz_parse_bytes` works on Linux/CI
- [ ] No panics triggered by edge cases in parser extensions