### PR TITLE
refactor: camino UTF-8 paths + lasso string interner foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,6 +428,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "camino"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+
+[[package]]
 name = "candle-core"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -641,6 +647,7 @@ version = "1.0.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
+ "camino",
  "candle-core",
  "candle-nn",
  "candle-transformers",
@@ -654,6 +661,7 @@ dependencies = [
  "hf-hub 0.5.0",
  "indicatif 0.18.4",
  "insta",
+ "lasso",
  "notify",
  "notify-debouncer-mini",
  "ort",
@@ -1077,6 +1085,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06d2e3287df1c007e74221c49ca10a95d557349e54b3a75dc2fb14712c751f04"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1831,6 +1853,16 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -2459,6 +2491,16 @@ checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
 dependencies = [
  "bitflags 1.3.2",
  "libc",
+]
+
+[[package]]
+name = "lasso"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e14eda50a3494b3bf7b9ce51c52434a761e383d7238ce1dd5dcec2fbc13e9fb"
+dependencies = [
+ "dashmap",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,12 @@ clap = { version = "4", features = ["derive"] }
 # Hashing
 sha2 = "0.10"
 
+# UTF-8 path types
+camino = "1"
+
+# String interning
+lasso = { version = "0.7", features = ["multi-threaded"] }
+
 # File system
 walkdir = "2"
 glob = "0.3"

--- a/src/embeddings.rs
+++ b/src/embeddings.rs
@@ -18,7 +18,7 @@
 //! postcard/zstd pattern as `graph.rs`.
 
 use std::collections::{HashMap, HashSet};
-use std::path::{Path, PathBuf};
+use camino::{Utf8Path, Utf8PathBuf};
 
 #[cfg(feature = "hnsw-index")]
 use usearch::{Index, IndexOptions, MetricKind, ScalarKind};
@@ -46,11 +46,11 @@ struct EmbeddingData {
 // Persistence helpers (delegates to crate::persistence)
 // ---------------------------------------------------------------------------
 
-fn save_embedding_data(data: &EmbeddingData, path: &Path) -> Result<()> {
+fn save_embedding_data(data: &EmbeddingData, path: &std::path::Path) -> Result<()> {
     persistence::save_blob(data, path, "embeddings")
 }
 
-fn load_embedding_data(path: &Path) -> Result<EmbeddingData> {
+fn load_embedding_data(path: &std::path::Path) -> Result<EmbeddingData> {
     persistence::load_blob(path, "embeddings")
 }
 
@@ -605,7 +605,7 @@ fn detect_provider() -> Option<Box<dyn EmbeddingProvider>> {
 /// Embedding storage backed by a postcard/zstd file.
 pub struct EmbeddingStore {
     data: EmbeddingData,
-    path: PathBuf,
+    path: Utf8PathBuf,
     provider: Option<Box<dyn EmbeddingProvider>>,
 }
 
@@ -613,14 +613,14 @@ impl EmbeddingStore {
     /// Open (or create) the embedding store.
     ///
     /// `store_path` should point to a `.embeddings.bin.zst` file.
-    pub fn new(store_path: &Path) -> Result<Self> {
+    pub fn new(store_path: &Utf8Path) -> Result<Self> {
         let data = if store_path.exists() {
-            match load_embedding_data(store_path) {
+            match load_embedding_data(store_path.as_std_path()) {
                 Ok(d) => d,
                 Err(e) => {
                     tracing::warn!(
                         "Could not load embeddings from {}: {} — starting empty",
-                        store_path.display(),
+                        store_path,
                         e
                     );
                     EmbeddingData::default()
@@ -686,7 +686,7 @@ impl EmbeddingStore {
 
     /// Persist in-memory state to disk.
     pub fn save(&self) -> Result<()> {
-        save_embedding_data(&self.data, &self.path)
+        save_embedding_data(&self.data, self.path.as_std_path())
     }
 
     /// Close the store (no-op — nothing to flush unless explicitly saved).
@@ -832,7 +832,7 @@ pub fn semantic_search(
     emb_store: &mut EmbeddingStore,
     limit: usize,
     compact: bool,
-    repo_root: &std::path::Path,
+    repo_root: &Utf8Path,
 ) -> Result<Vec<serde_json::Value>> {
     if emb_store.provider.is_none() {
         let nodes = store.search_nodes(query, limit)?;
@@ -897,7 +897,7 @@ fn nodes_from_scored(
     scored: Vec<(String, f64)>,
     store: &GraphStore,
     compact: bool,
-    repo_root: &std::path::Path,
+    repo_root: &Utf8Path,
 ) -> Result<Vec<serde_json::Value>> {
     let prefix = if compact { Some(crate::types::NormalizedPrefix::new(repo_root)) } else { None };
     let mut results = Vec::with_capacity(scored.len());
@@ -951,6 +951,10 @@ pub fn node_to_text(node: &GraphNode) -> String {
 mod tests {
     use super::*;
     use crate::types::{GraphNode, NodeKind};
+
+    fn p(path: &std::path::Path) -> &Utf8Path {
+        Utf8Path::from_path(path).expect("test path is valid UTF-8")
+    }
 
     #[test]
     fn cosine_similarity_identical_vectors() {
@@ -1034,7 +1038,7 @@ mod tests {
     fn embedding_store_count_empty() {
         let dir = tempfile::TempDir::new().unwrap();
         let path = dir.path().join("test.embeddings.bin.zst");
-        let store = EmbeddingStore::new(&path).unwrap();
+        let store = EmbeddingStore::new(p(&path)).unwrap();
         assert_eq!(store.count().unwrap(), 0);
     }
 
@@ -1042,14 +1046,14 @@ mod tests {
     fn embedding_store_save_reload_roundtrip() {
         let dir = tempfile::TempDir::new().unwrap();
         let path = dir.path().join("test.embeddings.bin.zst");
-        let mut store = EmbeddingStore::new(&path).unwrap();
+        let mut store = EmbeddingStore::new(p(&path)).unwrap();
         store.data.vectors.insert(
             "mod::foo".to_string(),
             (vec![1.0, 2.0, 3.0], "hash1".to_string(), "test".to_string()),
         );
         store.save().unwrap();
 
-        let reloaded = EmbeddingStore::new(&path).unwrap();
+        let reloaded = EmbeddingStore::new(p(&path)).unwrap();
         assert_eq!(reloaded.count().unwrap(), 1);
         let (vec, hash, provider) = reloaded.data.vectors.get("mod::foo").unwrap();
         assert_eq!(vec, &[1.0, 2.0, 3.0]);

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -7,7 +7,8 @@
 //! SQLite is no longer used here — see `embeddings.rs` for the embeddings DB.
 
 use std::collections::{BinaryHeap, HashMap, HashSet, VecDeque};
-use std::path::Path;
+
+use camino::{Utf8Path, Utf8PathBuf};
 
 use petgraph::stable_graph::StableGraph;
 use petgraph::visit::{EdgeRef, IntoEdgeReferences};
@@ -55,12 +56,12 @@ impl GraphData {
 // Persistence helpers (delegates to crate::persistence)
 // ---------------------------------------------------------------------------
 
-fn save(data: &GraphData, path: &Path) -> Result<()> {
-    persistence::save_blob(data, path, "graph")
+fn save(data: &GraphData, path: &Utf8Path) -> Result<()> {
+    persistence::save_blob(data, path.as_std_path(), "graph")
 }
 
-fn load(path: &Path) -> Result<GraphData> {
-    persistence::load_blob(path, "graph")
+fn load(path: &Utf8Path) -> Result<GraphData> {
+    persistence::load_blob(path.as_std_path(), "graph")
 }
 
 // ---------------------------------------------------------------------------
@@ -72,7 +73,7 @@ fn load(path: &Path) -> Result<GraphData> {
 pub struct GraphStore {
     data: GraphData,
     /// Path to the `.bin.zst` file.
-    bin_path: std::path::PathBuf,
+    bin_path: Utf8PathBuf,
 }
 
 impl GraphStore {
@@ -80,7 +81,7 @@ impl GraphStore {
     ///
     /// `db_path` is the path returned by `incremental::get_db_path()` —
     /// i.e. `<repo>/.code-review-graph/graph.bin.zst`.
-    pub fn new(db_path: &Path) -> Result<Self> {
+    pub fn new(db_path: &Utf8Path) -> Result<Self> {
         if let Some(parent) = db_path.parent() {
             std::fs::create_dir_all(parent)?;
         }
@@ -91,7 +92,7 @@ impl GraphStore {
                 Err(e) => {
                     tracing::warn!(
                         "Could not load graph from {}: {} — starting empty",
-                        db_path.display(),
+                        db_path,
                         e
                     );
                     GraphData::new()
@@ -998,6 +999,10 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
+    fn p(path: &std::path::Path) -> &Utf8Path {
+        Utf8Path::from_path(path).expect("test path is valid UTF-8")
+    }
+
     // -----------------------------------------------------------------------
     // Helper: create a fresh in-memory-backed GraphStore with a temp file path
     // -----------------------------------------------------------------------
@@ -1005,7 +1010,7 @@ mod tests {
     fn test_store() -> (GraphStore, TempDir) {
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("test.bin.zst");
-        let store = GraphStore::new(&path).unwrap();
+        let store = GraphStore::new(p(&path)).unwrap();
         (store, dir)
     }
 
@@ -1417,7 +1422,7 @@ mod tests {
         let path = dir.path().join("graph.bin.zst");
 
         {
-            let mut store = GraphStore::new(&path).unwrap();
+            let mut store = GraphStore::new(p(&path)).unwrap();
             let nodes = vec![make_node("roundtrip_fn", "f.py::roundtrip_fn", "f.py", NodeKind::Function)];
             store
                 .store_file_nodes_edges("f.py", &nodes, &[], "hash99")
@@ -1427,7 +1432,7 @@ mod tests {
         }
 
         // Reload from disk
-        let store2 = GraphStore::new(&path).unwrap();
+        let store2 = GraphStore::new(p(&path)).unwrap();
         let node = store2.get_node("f.py::roundtrip_fn").unwrap();
         assert!(node.is_some(), "node should survive save+load");
         assert_eq!(store2.get_metadata("key").unwrap(), Some("value".to_string()));
@@ -1445,7 +1450,7 @@ mod tests {
         std::fs::write(&path, b"BADBYTES_NOT_CRG_MAGIC").unwrap();
 
         // GraphStore::new should not panic — it falls back to empty graph
-        let store = GraphStore::new(&path).unwrap();
+        let store = GraphStore::new(p(&path)).unwrap();
         assert_eq!(store.get_stats().unwrap().total_nodes, 0);
     }
 
@@ -1458,7 +1463,7 @@ mod tests {
         data.extend_from_slice(&[0u8; 100]); // bad CRC + garbage compressed payload
         std::fs::write(&path, &data).unwrap();
 
-        let store = GraphStore::new(&path).unwrap();
+        let store = GraphStore::new(p(&path)).unwrap();
         assert_eq!(store.get_stats().unwrap().total_nodes, 0);
     }
 

--- a/src/incremental.rs
+++ b/src/incremental.rs
@@ -6,9 +6,10 @@
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::Read as _;
-use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::Duration;
+
+use camino::{Utf8Path, Utf8PathBuf};
 
 use chrono::Utc;
 use indicatif::{ProgressBar, ProgressStyle};
@@ -60,11 +61,15 @@ fn git_timeout() -> Duration {
 }
 
 /// Walk up from `start` to find the nearest `.git` directory.
-pub fn find_repo_root(start: Option<&Path>) -> Option<PathBuf> {
-    let start = start
+pub fn find_repo_root(start: Option<&Utf8Path>) -> Option<Utf8PathBuf> {
+    let start: Utf8PathBuf = start
         .map(|p| p.to_path_buf())
-        .or_else(|| std::env::current_dir().ok())?;
-    let mut current = start.as_path();
+        .or_else(|| {
+            std::env::current_dir().ok().and_then(|p| {
+                Utf8PathBuf::from_path_buf(p).ok()
+            })
+        })?;
+    let mut current: &Utf8Path = start.as_path();
     loop {
         if current.join(".git").exists() {
             return Some(current.to_path_buf());
@@ -77,22 +82,27 @@ pub fn find_repo_root(start: Option<&Path>) -> Option<PathBuf> {
 }
 
 /// Find the project root: git repo root if available, otherwise cwd.
-pub fn find_project_root(start: Option<&Path>) -> PathBuf {
+pub fn find_project_root(start: Option<&Utf8Path>) -> Utf8PathBuf {
     find_repo_root(start).unwrap_or_else(|| {
         start
             .map(|p| p.to_path_buf())
-            .unwrap_or_else(|| std::env::current_dir().unwrap_or_default())
+            .unwrap_or_else(|| {
+                std::env::current_dir()
+                    .ok()
+                    .and_then(|p| Utf8PathBuf::from_path_buf(p).ok())
+                    .unwrap_or_default()
+            })
     })
 }
 
 /// Determine the graph binary path for a repository.
 /// Creates `.code-review-graph/` directory and inner `.gitignore`.
-pub fn get_db_path(repo_root: &Path) -> PathBuf {
+pub fn get_db_path(repo_root: &Utf8Path) -> Utf8PathBuf {
     let crg_dir = repo_root.join(".code-review-graph");
     let graph_bin = crg_dir.join("graph.bin.zst");
 
     if let Err(e) = fs::create_dir_all(&crg_dir) {
-        warn!("Could not create {}: {}", crg_dir.display(), e);
+        warn!("Could not create {}: {}", crg_dir, e);
     }
 
     let inner_gitignore = crg_dir.join(".gitignore");
@@ -127,13 +137,13 @@ pub fn get_db_path(repo_root: &Path) -> PathBuf {
 }
 
 /// Determine the embeddings store path for a repository.
-pub fn get_embeddings_db_path(repo_root: &Path) -> PathBuf {
+pub fn get_embeddings_db_path(repo_root: &Utf8Path) -> Utf8PathBuf {
     repo_root
         .join(".code-review-graph")
         .join("embeddings.bin.zst")
 }
 
-fn load_ignore_patterns(repo_root: &Path) -> Vec<glob::Pattern> {
+fn load_ignore_patterns(repo_root: &Utf8Path) -> Vec<glob::Pattern> {
     let mut raw: Vec<String> = DEFAULT_IGNORE_PATTERNS.iter().map(|s| s.to_string()).collect();
     let ignore_file = repo_root.join(".code-review-graphignore");
     if let Ok(content) = fs::read_to_string(ignore_file) {
@@ -153,7 +163,7 @@ fn should_ignore(path: &str, patterns: &[glob::Pattern]) -> bool {
     patterns.iter().any(|p| p.matches(path))
 }
 
-fn is_binary(path: &Path) -> bool {
+fn is_binary(path: &std::path::Path) -> bool {
     let Ok(mut f) = fs::File::open(path) else { return true };
     let mut buf = [0u8; 8192];
     match f.read(&mut buf) {
@@ -182,7 +192,7 @@ fn now_iso() -> String {
     Utc::now().format("%Y-%m-%dT%H:%M:%S").to_string()
 }
 
-fn run_git(repo_root: &Path, args: &[&str]) -> Option<String> {
+fn run_git(repo_root: &Utf8Path, args: &[&str]) -> Option<String> {
     let timeout = git_timeout();
     let repo_root = repo_root.to_path_buf();
     // Clone args into owned Strings so the slice can be moved into the spawned thread.
@@ -191,7 +201,7 @@ fn run_git(repo_root: &Path, args: &[&str]) -> Option<String> {
     std::thread::spawn(move || {
         let result = Command::new("git")
             .args(&args)
-            .current_dir(&repo_root)
+            .current_dir(repo_root.as_std_path())
             .output();
         let _ = tx.send(result);
     });
@@ -209,7 +219,7 @@ fn run_git(repo_root: &Path, args: &[&str]) -> Option<String> {
 }
 
 /// Get list of changed files via `git diff`.
-pub fn get_changed_files(repo_root: &Path, base: &str) -> Vec<String> {
+pub fn get_changed_files(repo_root: &Utf8Path, base: &str) -> Vec<String> {
     // Try diff against base
     let out = run_git(repo_root, &["diff", "--name-only", base])
         .or_else(|| run_git(repo_root, &["diff", "--name-only", "--cached"]));
@@ -218,7 +228,7 @@ pub fn get_changed_files(repo_root: &Path, base: &str) -> Vec<String> {
 }
 
 /// Get all modified files (staged + unstaged + untracked).
-pub fn get_staged_and_unstaged(repo_root: &Path) -> Vec<String> {
+pub fn get_staged_and_unstaged(repo_root: &Utf8Path) -> Vec<String> {
     let out = match run_git(repo_root, &["status", "--porcelain"]) {
         Some(s) => s,
         None => return vec![],
@@ -240,7 +250,7 @@ pub fn get_staged_and_unstaged(repo_root: &Path) -> Vec<String> {
 }
 
 /// Get all files tracked by git.
-pub fn get_all_tracked_files(repo_root: &Path) -> Vec<String> {
+pub fn get_all_tracked_files(repo_root: &Utf8Path) -> Vec<String> {
     run_git(repo_root, &["ls-files"])
         .map(|s| parse_file_lines(&s))
         .unwrap_or_default()
@@ -255,7 +265,7 @@ fn parse_file_lines(s: &str) -> Vec<String> {
 }
 
 /// Collect all parseable files in the repo, respecting ignore patterns.
-pub fn collect_all_files(repo_root: &Path) -> Vec<String> {
+pub fn collect_all_files(repo_root: &Utf8Path) -> Vec<String> {
     let ignore_patterns = load_ignore_patterns(repo_root);
     let parser = CodeParser::new();
 
@@ -270,7 +280,7 @@ pub fn collect_all_files(repo_root: &Path) -> Vec<String> {
             .filter(|e| e.file_type().is_file())
             .filter_map(|e| {
                 e.path()
-                    .strip_prefix(repo_root)
+                    .strip_prefix(repo_root.as_std_path())
                     .ok()
                     .map(|p| p.to_string_lossy().replace('\\', "/"))
             })
@@ -283,13 +293,13 @@ pub fn collect_all_files(repo_root: &Path) -> Vec<String> {
             continue;
         }
         let full_path = repo_root.join(&rel_path);
-        if !full_path.is_file() || full_path.is_symlink() {
+        if !full_path.exists() || !full_path.is_file() || full_path.is_symlink() {
             continue;
         }
-        if parser.detect_language(&full_path).is_none() {
+        if parser.detect_language(full_path.as_std_path()).is_none() {
             continue;
         }
-        if is_binary(&full_path) {
+        if is_binary(full_path.as_std_path()) {
             continue;
         }
         files.push(rel_path);
@@ -361,14 +371,14 @@ type ParseResult = std::result::Result<
 /// This is the parallel-safe half: `CodeParser` is a unit struct that creates a
 /// fresh `tree_sitter::Parser` per call, so it is safe to invoke from multiple
 /// rayon threads simultaneously.
-fn parse_file_parallel(parser: &CodeParser, repo_root: &Path, rel_path: &str) -> ParseResult {
+fn parse_file_parallel(parser: &CodeParser, repo_root: &Utf8Path, rel_path: &str) -> ParseResult {
     let full_path = repo_root.join(rel_path);
-    let source = std::fs::read(&full_path).map_err(|e| BuildError {
+    let source = std::fs::read(full_path.as_std_path()).map_err(|e| BuildError {
         file: rel_path.to_owned(),
         error: e.to_string(),
     })?;
     let fhash = sha256_bytes(&source);
-    let (nodes, edges) = parser.parse_bytes(&full_path, &source).map_err(|e| {
+    let (nodes, edges) = parser.parse_bytes(full_path.as_std_path(), &source).map_err(|e| {
         warn!("Error parsing {}: {}", rel_path, e);
         BuildError {
             file: rel_path.to_owned(),
@@ -379,7 +389,7 @@ fn parse_file_parallel(parser: &CodeParser, repo_root: &Path, rel_path: &str) ->
 }
 
 /// Full rebuild of the entire graph.
-pub fn full_build(repo_root: &Path, store: &mut GraphStore) -> Result<BuildResult> {
+pub fn full_build(repo_root: &Utf8Path, store: &mut GraphStore) -> Result<BuildResult> {
     let parser = CodeParser::new();
     let files = collect_all_files(repo_root);
     let file_count = files.len();
@@ -388,7 +398,7 @@ pub fn full_build(repo_root: &Path, store: &mut GraphStore) -> Result<BuildResul
     let existing_files = store.get_all_files()?;
     let current_abs: HashSet<String> = files
         .iter()
-        .map(|f| repo_root.join(f).to_string_lossy().into_owned())
+        .map(|f| repo_root.join(f).as_str().to_owned())
         .collect();
     for stale in existing_files {
         if !current_abs.contains(&stale) {
@@ -440,7 +450,7 @@ pub fn full_build(repo_root: &Path, store: &mut GraphStore) -> Result<BuildResul
             Ok((rel_path, nodes, edges, fhash)) => {
                 let full_path = repo_root.join(&rel_path);
                 match store.store_file_nodes_only(
-                    &full_path.to_string_lossy(),
+                    full_path.as_str(),
                     &nodes,
                     &fhash,
                 ) {
@@ -480,7 +490,7 @@ pub fn full_build(repo_root: &Path, store: &mut GraphStore) -> Result<BuildResul
 
 /// Incremental update: re-parse changed + dependent files only.
 pub fn incremental_update(
-    repo_root: &Path,
+    repo_root: &Utf8Path,
     store: &mut GraphStore,
     base: &str,
     changed_files: Option<Vec<String>>,
@@ -505,12 +515,12 @@ pub fn incremental_update(
     // Find dependent files
     let mut dependent_files: HashSet<String> = HashSet::new();
     for rel_path in &changed_files {
-        let full_path = repo_root.join(rel_path).to_string_lossy().into_owned();
+        let full_path = repo_root.join(rel_path).as_str().to_owned();
         let deps = find_dependents(store, &full_path)?;
         for d in deps {
-            let rel = Path::new(&d)
+            let rel = Utf8Path::new(&d)
                 .strip_prefix(repo_root)
-                .map(|p| p.to_string_lossy().into_owned())
+                .map(|p| p.as_str().to_owned())
                 .unwrap_or(d);
             dependent_files.insert(rel);
         }
@@ -541,16 +551,16 @@ pub fn incremental_update(
         }
         let abs_path = repo_root.join(rel_path);
         if !abs_path.is_file() {
-            let _ = store.remove_file_data(&abs_path.to_string_lossy());
+            let _ = store.remove_file_data(abs_path.as_str());
             continue;
         }
-        if parser.detect_language(&abs_path).is_none() {
+        if parser.detect_language(abs_path.as_std_path()).is_none() {
             continue;
         }
 
-        let abs_path_str = abs_path.to_string_lossy().into_owned();
+        let abs_path_str = abs_path.as_str().to_owned();
 
-        let source = match fs::read(&abs_path) {
+        let source = match fs::read(abs_path.as_std_path()) {
             Ok(bytes) => bytes,
             Err(_) => continue,
         };
@@ -562,7 +572,7 @@ pub fn incremental_update(
 
         let old_hashes = store.get_body_hashes(&abs_path_str);
 
-        match parser.parse_bytes(&abs_path, &source) {
+        match parser.parse_bytes(abs_path.as_std_path(), &source) {
             Ok((nodes, edges)) => {
                 parsed_files.push(ParsedFile {
                     abs_path_str,
@@ -628,10 +638,10 @@ pub fn incremental_update(
 }
 
 /// Watch for file changes and auto-update the graph.
-pub fn watch(repo_root: &Path, store: &mut GraphStore) -> Result<()> {
+pub fn watch(repo_root: &Utf8Path, store: &mut GraphStore) -> Result<()> {
     let parser = CodeParser::new();
     let ignore_patterns = load_ignore_patterns(repo_root);
-    let repo_root = repo_root.to_path_buf();
+    let repo_root_std = repo_root.as_std_path().to_path_buf();
 
     // Wrap store in Arc<Mutex<>> so it can be shared with the event handler.
     // Since GraphStore doesn't implement Send, we use a Mutex on the main thread
@@ -643,10 +653,10 @@ pub fn watch(repo_root: &Path, store: &mut GraphStore) -> Result<()> {
 
     debouncer
         .watcher()
-        .watch(&repo_root, RecursiveMode::Recursive)
+        .watch(&repo_root_std, RecursiveMode::Recursive)
         .map_err(|e| crate::error::CrgError::Other(e.to_string()))?;
 
-    info!("Watching {} for changes... (Ctrl+C to stop)", repo_root.display());
+    info!("Watching {} for changes... (Ctrl+C to stop)", repo_root);
 
     let mut batch_count: u32 = 0;
     const COMPACT_INTERVAL: u32 = 50;
@@ -660,15 +670,16 @@ pub fn watch(repo_root: &Path, store: &mut GraphStore) -> Result<()> {
             }
         };
 
-        let mut paths_to_update: HashSet<PathBuf> = HashSet::new();
-        let mut paths_to_remove: HashSet<PathBuf> = HashSet::new();
+        // notify returns std::path::PathBuf; keep them as-is until boundaries.
+        let mut paths_to_update: HashSet<std::path::PathBuf> = HashSet::new();
+        let mut paths_to_remove: HashSet<std::path::PathBuf> = HashSet::new();
 
         for event in events {
             let path = event.path;
             if path.is_symlink() {
                 continue;
             }
-            let rel = match path.strip_prefix(&repo_root) {
+            let rel = match path.strip_prefix(&repo_root_std) {
                 Ok(r) => r.to_string_lossy().replace('\\', "/"),
                 Err(_) => continue,
             };
@@ -690,7 +701,7 @@ pub fn watch(repo_root: &Path, store: &mut GraphStore) -> Result<()> {
             if let Err(e) = store.remove_file_data(&abs_str) {
                 error!("Error removing {}: {}", abs_str, e);
             } else {
-                let rel = path.strip_prefix(&repo_root)
+                let rel = path.strip_prefix(&repo_root_std)
                     .map(|p| p.display().to_string())
                     .unwrap_or_else(|_| abs_str.clone());
                 info!("Removed: {}", rel);
@@ -723,7 +734,7 @@ pub fn watch(repo_root: &Path, store: &mut GraphStore) -> Result<()> {
                                     &now_iso(),
                                 );
                                 let _ = store.commit();
-                                let rel = path.strip_prefix(&repo_root)
+                                let rel = path.strip_prefix(&repo_root_std)
                                     .map(|p| p.display().to_string())
                                     .unwrap_or_else(|_| abs_str.clone());
                                 info!("Updated: {} ({} nodes, {} edges)", rel, n, e);
@@ -756,7 +767,7 @@ pub fn watch(repo_root: &Path, store: &mut GraphStore) -> Result<()> {
 // ---------------------------------------------------------------------------
 
 /// Public wrapper around the private `load_ignore_patterns`.
-pub fn load_ignore_patterns_pub(repo_root: &Path) -> Vec<glob::Pattern> {
+pub fn load_ignore_patterns_pub(repo_root: &Utf8Path) -> Vec<glob::Pattern> {
     load_ignore_patterns(repo_root)
 }
 
@@ -766,7 +777,7 @@ pub fn should_ignore_pub(path: &str, patterns: &[glob::Pattern]) -> bool {
 }
 
 /// Public wrapper around the private `is_binary`.
-pub fn is_binary_pub(path: &Path) -> bool {
+pub fn is_binary_pub(path: &std::path::Path) -> bool {
     is_binary(path)
 }
 
@@ -785,6 +796,12 @@ mod tests {
     use std::fs;
     use tempfile::TempDir;
 
+    /// Convert a `&std::path::Path` to `&Utf8Path`, panicking on non-UTF-8 paths.
+    /// Used in tests where `TempDir::path()` returns `&std::path::Path`.
+    fn p(path: &std::path::Path) -> &Utf8Path {
+        Utf8Path::from_path(path).expect("test path is not valid UTF-8")
+    }
+
     // -----------------------------------------------------------------------
     // find_repo_root
     // -----------------------------------------------------------------------
@@ -796,9 +813,12 @@ mod tests {
         let subdir = dir.path().join("src");
         fs::create_dir(&subdir).unwrap();
 
-        let root = find_repo_root(Some(&subdir));
+        let root = find_repo_root(Some(Utf8Path::from_path(&subdir).unwrap()));
         assert!(root.is_some(), "should find repo root");
-        assert_eq!(root.unwrap().canonicalize().unwrap(), dir.path().canonicalize().unwrap());
+        assert_eq!(
+            root.unwrap().as_std_path().canonicalize().unwrap(),
+            dir.path().canonicalize().unwrap()
+        );
     }
 
     #[test]
@@ -813,7 +833,7 @@ mod tests {
         // We can't guarantee the system tmp dir is not inside a git repo, so
         // we just verify the function doesn't panic and returns Some or None.
         // The important thing is it terminates.
-        let _ = find_repo_root(Some(&leaf));
+        let _ = find_repo_root(Utf8Path::from_path(&leaf).map(Some).unwrap_or(None));
     }
 
     // -----------------------------------------------------------------------
@@ -823,17 +843,17 @@ mod tests {
     #[test]
     fn get_db_path_creates_crg_directory() {
         let dir = TempDir::new().unwrap();
-        let path = get_db_path(dir.path());
+        let path = get_db_path(p(dir.path()));
 
         let crg_dir = dir.path().join(".code-review-graph");
         assert!(crg_dir.is_dir(), ".code-review-graph dir should be created");
-        assert_eq!(path, crg_dir.join("graph.bin.zst"));
+        assert_eq!(path.as_std_path(), crg_dir.join("graph.bin.zst"));
     }
 
     #[test]
     fn get_db_path_creates_gitignore() {
         let dir = TempDir::new().unwrap();
-        get_db_path(dir.path());
+        get_db_path(p(dir.path()));
 
         let gitignore = dir.path().join(".code-review-graph").join(".gitignore");
         assert!(gitignore.exists(), ".gitignore should be created inside .code-review-graph");
@@ -867,7 +887,7 @@ mod tests {
 
     #[test]
     fn should_ignore_matches_node_modules() {
-        let patterns = load_ignore_patterns_pub(Path::new("."));
+        let patterns = load_ignore_patterns_pub(Utf8Path::new("."));
         assert!(
             should_ignore_pub("node_modules/react/index.js", &patterns),
             "node_modules should be ignored"
@@ -876,7 +896,7 @@ mod tests {
 
     #[test]
     fn should_ignore_matches_git_dir() {
-        let patterns = load_ignore_patterns_pub(Path::new("."));
+        let patterns = load_ignore_patterns_pub(Utf8Path::new("."));
         assert!(
             should_ignore_pub(".git/config", &patterns),
             ".git should be ignored"
@@ -885,7 +905,7 @@ mod tests {
 
     #[test]
     fn should_ignore_does_not_ignore_src_files() {
-        let patterns = load_ignore_patterns_pub(Path::new("."));
+        let patterns = load_ignore_patterns_pub(Utf8Path::new("."));
         assert!(
             !should_ignore_pub("src/main.py", &patterns),
             "src/main.py should not be ignored"
@@ -940,7 +960,7 @@ mod tests {
         // Create a legitimate Python file
         fs::write(dir.path().join("main.py"), b"def foo(): pass\n").unwrap();
 
-        let files = collect_all_files(dir.path());
+        let files = collect_all_files(p(dir.path()));
         // node_modules should be excluded
         assert!(
             !files.iter().any(|f| f.contains("node_modules")),
@@ -976,9 +996,9 @@ mod tests {
         )
         .unwrap();
 
-        let db_path = get_db_path(dir.path());
+        let db_path = get_db_path(p(dir.path()));
         let mut store = crate::graph::GraphStore::new(&db_path).unwrap();
-        let result = full_build(dir.path(), &mut store).unwrap();
+        let result = full_build(p(dir.path()), &mut store).unwrap();
 
         assert!(result.files_parsed >= 2, "should parse at least 2 files");
         assert!(result.total_nodes > 0, "should extract nodes");
@@ -996,13 +1016,13 @@ mod tests {
         let dir = TempDir::new().unwrap();
         fs::write(dir.path().join("app.py"), b"def foo(): pass\n").unwrap();
 
-        let db_path = get_db_path(dir.path());
+        let db_path = get_db_path(p(dir.path()));
         let mut store = crate::graph::GraphStore::new(&db_path).unwrap();
-        full_build(dir.path(), &mut store).unwrap();
+        full_build(p(dir.path()), &mut store).unwrap();
 
         // Call incremental with the same files — no hash changes
         let result = incremental_update(
-            dir.path(),
+            p(dir.path()),
             &mut store,
             "HEAD",
             Some(vec!["app.py".to_string()]),
@@ -1022,9 +1042,9 @@ mod tests {
         let dir = TempDir::new().unwrap();
         fs::write(dir.path().join("app.py"), b"def foo(): pass\n").unwrap();
 
-        let db_path = get_db_path(dir.path());
+        let db_path = get_db_path(p(dir.path()));
         let mut store = crate::graph::GraphStore::new(&db_path).unwrap();
-        full_build(dir.path(), &mut store).unwrap();
+        full_build(p(dir.path()), &mut store).unwrap();
 
         // Modify the file
         fs::write(
@@ -1034,7 +1054,7 @@ mod tests {
         .unwrap();
 
         let result = incremental_update(
-            dir.path(),
+            p(dir.path()),
             &mut store,
             "HEAD",
             Some(vec!["app.py".to_string()]),
@@ -1051,10 +1071,10 @@ mod tests {
     #[test]
     fn incremental_update_empty_changed_list_returns_zero() {
         let dir = TempDir::new().unwrap();
-        let db_path = get_db_path(dir.path());
+        let db_path = get_db_path(p(dir.path()));
         let mut store = crate::graph::GraphStore::new(&db_path).unwrap();
 
-        let result = incremental_update(dir.path(), &mut store, "HEAD", Some(vec![])).unwrap();
+        let result = incremental_update(p(dir.path()), &mut store, "HEAD", Some(vec![])).unwrap();
         assert_eq!(result.files_updated, 0);
         assert_eq!(result.total_nodes, 0);
     }
@@ -1131,7 +1151,7 @@ mod tests {
     #[test]
     fn find_dependents_returns_caller_file() {
         let dir = TempDir::new().unwrap();
-        let db_path = get_db_path(dir.path());
+        let db_path = get_db_path(p(dir.path()));
         let mut store = crate::graph::GraphStore::new(&db_path).unwrap();
 
         let abs_a = dir.path().join("a.py").to_string_lossy().into_owned();
@@ -1156,7 +1176,7 @@ mod tests {
     #[test]
     fn find_dependents_returns_empty_for_no_dependents() {
         let dir = TempDir::new().unwrap();
-        let db_path = get_db_path(dir.path());
+        let db_path = get_db_path(p(dir.path()));
         let mut store = crate::graph::GraphStore::new(&db_path).unwrap();
 
         let abs_b = dir.path().join("b.py").to_string_lossy().into_owned();
@@ -1179,7 +1199,7 @@ mod tests {
         // A file should not appear in its own dependents list even if a
         // self-referential edge somehow exists in the graph.
         let dir = TempDir::new().unwrap();
-        let db_path = get_db_path(dir.path());
+        let db_path = get_db_path(p(dir.path()));
         let mut store = crate::graph::GraphStore::new(&db_path).unwrap();
 
         let abs_b = dir.path().join("b.py").to_string_lossy().into_owned();
@@ -1202,7 +1222,7 @@ mod tests {
     #[test]
     fn find_dependents_returns_multiple_callers() {
         let dir = TempDir::new().unwrap();
-        let db_path = get_db_path(dir.path());
+        let db_path = get_db_path(p(dir.path()));
         let mut store = crate::graph::GraphStore::new(&db_path).unwrap();
 
         let abs_a = dir.path().join("a.py").to_string_lossy().into_owned();
@@ -1246,7 +1266,7 @@ mod tests {
         // An ImportsFrom edge at the node level (source imports a symbol from b.py)
         // should also be detected.
         let dir = TempDir::new().unwrap();
-        let db_path = get_db_path(dir.path());
+        let db_path = get_db_path(p(dir.path()));
         let mut store = crate::graph::GraphStore::new(&db_path).unwrap();
 
         let abs_a = dir.path().join("a.py").to_string_lossy().into_owned();
@@ -1314,13 +1334,13 @@ mod tests {
             .output()
             .unwrap();
 
-        let db_path = get_db_path(dir.path());
+        let db_path = get_db_path(p(dir.path()));
         let mut store = crate::graph::GraphStore::new(&db_path).unwrap();
-        full_build(dir.path(), &mut store).unwrap();
+        full_build(p(dir.path()), &mut store).unwrap();
 
         // Call incremental with the same unchanged file — hash matches what was stored
         let result = incremental_update(
-            dir.path(),
+            p(dir.path()),
             &mut store,
             "HEAD",
             Some(vec!["stable.py".to_string()]),
@@ -1372,16 +1392,16 @@ mod tests {
             .output()
             .unwrap();
 
-        let db_path = get_db_path(dir.path());
+        let db_path = get_db_path(p(dir.path()));
         let mut store = crate::graph::GraphStore::new(&db_path).unwrap();
-        full_build(dir.path(), &mut store).unwrap();
+        full_build(p(dir.path()), &mut store).unwrap();
 
         // Modify the file on disk — new content produces a different hash
         let modified = b"def greet(): return 'world'\ndef farewell(): pass\n";
         fs::write(dir.path().join("greet.py"), modified).unwrap();
 
         let result = incremental_update(
-            dir.path(),
+            p(dir.path()),
             &mut store,
             "HEAD",
             Some(vec!["greet.py".to_string()]),
@@ -1405,7 +1425,7 @@ mod tests {
             return;
         }
         let dir = TempDir::new().unwrap();
-        let db_path = get_db_path(dir.path());
+        let db_path = get_db_path(p(dir.path()));
         let mut store = crate::graph::GraphStore::new(&db_path).unwrap();
 
         // Manually populate the graph: a.py calls func_b defined in b.py
@@ -1422,7 +1442,7 @@ mod tests {
 
         // Trigger incremental on b.py — a.py should appear in dependent_files
         let result = incremental_update(
-            dir.path(),
+            p(dir.path()),
             &mut store,
             "HEAD",
             Some(vec!["b.py".to_string()]),

--- a/src/intern.rs
+++ b/src/intern.rs
@@ -1,0 +1,22 @@
+//! Global string interner for high-frequency fields.
+//!
+//! `file_path` and `language` fields repeat across thousands of nodes.
+//! Interning reduces memory (~14 unique languages, ~1000 unique file paths
+//! in a typical repo) and makes equality checks O(1).
+
+use lasso::{Spur, ThreadedRodeo};
+use std::sync::OnceLock;
+
+static INTERNER: OnceLock<ThreadedRodeo> = OnceLock::new();
+
+pub fn interner() -> &'static ThreadedRodeo {
+    INTERNER.get_or_init(ThreadedRodeo::default)
+}
+
+pub fn intern(s: &str) -> Spur {
+    interner().get_or_intern(s)
+}
+
+pub fn resolve(key: Spur) -> &'static str {
+    interner().resolve(&key)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod embeddings;
 pub mod error;
 pub mod graph;
 pub mod incremental;
+pub mod intern;
 pub mod parser;
 pub mod persistence;
 pub mod server;

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,8 +13,7 @@
 //!   code-review-graph config list
 //!   code-review-graph config reset
 
-use std::path::PathBuf;
-
+use camino::Utf8PathBuf;
 use clap::{Parser, Subcommand};
 
 #[derive(Parser)]
@@ -191,7 +190,7 @@ async fn handle_command(cmd: Commands) -> anyhow::Result<()> {
             let store = code_review_graph::graph::GraphStore::new(&db_path)?;
             let html_path = root.join(".code-review-graph").join("graph.html");
             code_review_graph::visualization::generate_html(&store, &html_path)?;
-            println!("Visualization: {}", html_path.display());
+            println!("Visualization: {}", html_path);
             println!("Open in browser to explore your codebase graph.");
             store.close()?;
         }
@@ -217,13 +216,13 @@ async fn handle_command(cmd: Commands) -> anyhow::Result<()> {
 fn resolve_project_root(
     repo: Option<&str>,
     require_git: bool,
-) -> anyhow::Result<PathBuf> {
+) -> anyhow::Result<Utf8PathBuf> {
     use code_review_graph::incremental;
 
     if let Some(r) = repo {
-        let path = PathBuf::from(r);
+        let path = Utf8PathBuf::from(r);
         if !path.is_dir() {
-            anyhow::bail!("Repository path is not a directory: {}", path.display());
+            anyhow::bail!("Repository path is not a directory: {}", path);
         }
         return Ok(path);
     }
@@ -245,8 +244,8 @@ fn resolve_project_root(
 fn handle_install(repo: Option<&str>, dry_run: bool) -> anyhow::Result<()> {
     use code_review_graph::incremental;
 
-    let root: PathBuf = if let Some(r) = repo {
-        PathBuf::from(r)
+    let root: Utf8PathBuf = if let Some(r) = repo {
+        Utf8PathBuf::from(r)
     } else {
         incremental::find_project_root(None)
     };
@@ -272,7 +271,7 @@ fn handle_install(repo: Option<&str>, dry_run: bool) -> anyhow::Result<()> {
                     .and_then(|s| s.get("code-review-graph"))
                     .is_some()
                 {
-                    println!("Already configured in {}", mcp_path.display());
+                    println!("Already configured in {}", mcp_path);
                     return Ok(());
                 }
                 // Merge our entry in
@@ -292,7 +291,7 @@ fn handle_install(repo: Option<&str>, dry_run: bool) -> anyhow::Result<()> {
             Err(_) => {
                 eprintln!(
                     "Warning: existing {} has invalid JSON, overwriting.",
-                    mcp_path.display()
+                    mcp_path
                 );
                 entry
             }
@@ -304,7 +303,7 @@ fn handle_install(repo: Option<&str>, dry_run: bool) -> anyhow::Result<()> {
     let json_str = serde_json::to_string_pretty(&final_config)?;
 
     if dry_run {
-        println!("[dry-run] Would write to {}:", mcp_path.display());
+        println!("[dry-run] Would write to {}:", mcp_path);
         println!("{}", json_str);
         println!();
         println!("[dry-run] No files were modified.");
@@ -312,7 +311,7 @@ fn handle_install(repo: Option<&str>, dry_run: bool) -> anyhow::Result<()> {
     }
 
     std::fs::write(&mcp_path, [json_str.as_bytes(), b"\n"].concat())?;
-    println!("Created {}", mcp_path.display());
+    println!("Created {}", mcp_path);
     println!();
     println!("Next steps:");
     println!("  1. code-review-graph build    # build the knowledge graph");

--- a/src/server.rs
+++ b/src/server.rs
@@ -20,8 +20,9 @@ use rmcp::{
 };
 use serde::Deserialize;
 use std::collections::HashSet;
-use std::path::PathBuf;
 use std::sync::Arc;
+
+use camino::Utf8PathBuf;
 use std::time::Duration;
 
 // ---------------------------------------------------------------------------
@@ -503,11 +504,11 @@ impl ServerHandler for CodeReviewServer {
 // Entry point
 // ---------------------------------------------------------------------------
 
-/// Resolve a server-level repo root string to a `PathBuf`, or fall back to
+/// Resolve a server-level repo root string to a `Utf8PathBuf`, or fall back to
 /// the project root auto-detection logic used by `tools.rs`.
-fn resolve_root(repo_root: Option<&str>) -> PathBuf {
+fn resolve_root(repo_root: Option<&str>) -> Utf8PathBuf {
     match repo_root {
-        Some(p) => PathBuf::from(p),
+        Some(p) => Utf8PathBuf::from(p),
         None => crate::incremental::find_project_root(None),
     }
 }
@@ -570,7 +571,7 @@ fn watcher_parse_and_store(
 /// processes the batch, saves to disk, then drops the store. This keeps the
 /// locking surface minimal and is safe with the per-call `get_store()` pattern
 /// used by the tool handlers.
-fn run_background_watcher(repo_root: PathBuf) -> crate::error::Result<()> {
+fn run_background_watcher(repo_root: Utf8PathBuf) -> crate::error::Result<()> {
     use notify::RecursiveMode;
     use notify_debouncer_mini::{new_debouncer, DebounceEventResult};
     use crate::incremental::{get_db_path, load_ignore_patterns_pub, find_dependents};
@@ -591,12 +592,12 @@ fn run_background_watcher(repo_root: PathBuf) -> crate::error::Result<()> {
         .map_err(|e| crate::error::CrgError::Other(e.to_string()))?;
     debouncer
         .watcher()
-        .watch(&repo_root, RecursiveMode::Recursive)
+        .watch(repo_root.as_std_path(), RecursiveMode::Recursive)
         .map_err(|e| crate::error::CrgError::Other(e.to_string()))?;
 
     tracing::info!(
         "Background watcher active — watching {}",
-        repo_root.display()
+        repo_root
     );
 
     for result in rx {
@@ -608,15 +609,16 @@ fn run_background_watcher(repo_root: PathBuf) -> crate::error::Result<()> {
             }
         };
 
-        let mut paths_to_update: HashSet<PathBuf> = HashSet::new();
-        let mut paths_to_remove: HashSet<PathBuf> = HashSet::new();
+        // notify returns std::path::PathBuf — keep as-is until we need string boundaries
+        let mut paths_to_update: HashSet<std::path::PathBuf> = HashSet::new();
+        let mut paths_to_remove: HashSet<std::path::PathBuf> = HashSet::new();
 
         for event in events {
             let path = event.path;
             if path.is_symlink() {
                 continue;
             }
-            let rel = match path.strip_prefix(&repo_root) {
+            let rel = match path.strip_prefix(repo_root.as_std_path()) {
                 Ok(r) => r.to_string_lossy().replace('\\', "/"),
                 Err(_) => continue,
             };
@@ -653,7 +655,7 @@ fn run_background_watcher(repo_root: PathBuf) -> crate::error::Result<()> {
                 tracing::error!("Watcher remove {}: {}", abs_str, e);
             } else {
                 let rel = path
-                    .strip_prefix(&repo_root)
+                    .strip_prefix(repo_root.as_std_path())
                     .map(|p| p.display().to_string())
                     .unwrap_or_else(|_| abs_str.clone());
                 tracing::info!("Watcher removed: {}", rel);
@@ -680,7 +682,7 @@ fn run_background_watcher(repo_root: PathBuf) -> crate::error::Result<()> {
                         &chrono::Utc::now().format("%Y-%m-%dT%H:%M:%S").to_string(),
                     );
                     let rel = path
-                        .strip_prefix(&repo_root)
+                        .strip_prefix(repo_root.as_std_path())
                         .map(|p| p.display().to_string())
                         .unwrap_or_else(|_| abs_str.clone());
                     tracing::info!(
@@ -696,7 +698,7 @@ fn run_background_watcher(repo_root: PathBuf) -> crate::error::Result<()> {
                             continue;
                         }
                         processed.insert(dep_path.clone());
-                        let dep = std::path::PathBuf::from(dep_path);
+                        let dep = std::path::Path::new(dep_path);
                         let dep_old_tree = tree_cache.get(dep_path.as_str());
                         match watcher_parse_and_store(&parser, &mut store, &dep, dep_old_tree) {
                             Ok(Some((dn, de, dep_new_tree))) => {
@@ -718,7 +720,7 @@ fn run_background_watcher(repo_root: PathBuf) -> crate::error::Result<()> {
                 }
                 Ok(None) => {
                     let rel = path
-                        .strip_prefix(&repo_root)
+                        .strip_prefix(repo_root.as_std_path())
                         .map(|p| p.display().to_string())
                         .unwrap_or_else(|_| abs_str.clone());
                     tracing::debug!("Watcher skipped (hash unchanged): {}", rel);

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -12,8 +12,9 @@
 //! 9. find_large_functions
 
 use std::collections::{HashMap, HashSet};
-use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
+
+use camino::{Utf8Path, Utf8PathBuf};
 
 use serde_json::{json, Value};
 
@@ -25,7 +26,7 @@ use crate::types::{edge_to_dict, node_to_dict, NormalizedPrefix, EdgeKind};
 
 /// Wrapper: build a node dict, then strip repo-root prefix if compact.
 /// For batch results, prefer `node_dict_batch` with a pre-computed prefix.
-fn node_dict(node: &crate::types::GraphNode, compact: bool, root: &Path) -> Value {
+fn node_dict(node: &crate::types::GraphNode, compact: bool, root: &Utf8Path) -> Value {
     let mut d = node_to_dict(node, compact);
     if compact {
         NormalizedPrefix::new(root).strip(&mut d);
@@ -99,29 +100,32 @@ fn is_builtin_call(name: &str) -> bool {
 // ---------------------------------------------------------------------------
 
 /// Validate that a path is a plausible project root.
-fn validate_repo_root(path: &Path) -> Result<PathBuf> {
-    let resolved = path.canonicalize().map_err(|e| {
-        CrgError::InvalidRepoRoot(format!("{}: {}", path.display(), e))
+fn validate_repo_root(path: &Utf8Path) -> Result<Utf8PathBuf> {
+    let resolved_std = path.as_std_path().canonicalize().map_err(|e| {
+        CrgError::InvalidRepoRoot(format!("{}: {}", path, e))
+    })?;
+    let resolved = Utf8PathBuf::from_path_buf(resolved_std).map_err(|p| {
+        CrgError::InvalidRepoRoot(format!("non-UTF-8 path: {}", p.display()))
     })?;
     if !resolved.is_dir() {
         return Err(CrgError::InvalidRepoRoot(format!(
             "not a directory: {}",
-            resolved.display()
+            resolved
         )));
     }
     if !resolved.join(".git").exists() && !resolved.join(".code-review-graph").exists() {
         return Err(CrgError::InvalidRepoRoot(format!(
             "no .git or .code-review-graph found: {}",
-            resolved.display()
+            resolved
         )));
     }
     Ok(resolved)
 }
 
 /// Resolve repo root and open the graph store.
-fn get_store(repo_root: Option<&str>) -> Result<(GraphStore, PathBuf)> {
+fn get_store(repo_root: Option<&str>) -> Result<(GraphStore, Utf8PathBuf)> {
     let root = match repo_root {
-        Some(p) => validate_repo_root(Path::new(p))?,
+        Some(p) => validate_repo_root(Utf8Path::new(p))?,
         None => incremental::find_project_root(None),
     };
     let db_path = incremental::get_db_path(&root);
@@ -136,7 +140,7 @@ fn get_store(repo_root: Option<&str>) -> Result<(GraphStore, PathBuf)> {
 /// Check if the graph is stale and run a quick incremental update if needed.
 /// Only checks git status (fast, ~10-50ms) — doesn't re-hash all files.
 /// Skipped if the graph was updated less than 2 seconds ago.
-fn maybe_auto_update(store: &mut GraphStore, repo_root: &Path) {
+fn maybe_auto_update(store: &mut GraphStore, repo_root: &Utf8Path) {
     // Skip if graph was updated less than 2 seconds ago
     if let Ok(Some(last)) = store.get_metadata("last_updated") {
         if let Ok(last_time) = chrono::NaiveDateTime::parse_from_str(&last, "%Y-%m-%dT%H:%M:%S") {
@@ -263,7 +267,7 @@ pub fn get_impact_radius(
     }
 
     let abs_files: Vec<String> = files.iter()
-        .map(|f| root.join(f).to_string_lossy().into_owned())
+        .map(|f| root.join(f).as_str().to_owned())
         .collect();
 
     let impact = store.get_impact_radius(&abs_files, max_depth, MAX_RESULTS, None)?;
@@ -494,7 +498,7 @@ pub fn query_graph(
         QueryPattern::ImportersOf => {
             let abs_target = node.as_ref()
                 .map(|n| n.file_path.clone())
-                .unwrap_or_else(|| root.join(target).to_string_lossy().into_owned());
+                .unwrap_or_else(|| root.join(target).as_str().to_owned());
             for e in store.get_edges_by_target(&abs_target)? {
                 if e.kind == EdgeKind::ImportsFrom {
                     results.push(json!({ "importer": e.source_qualified, "file": e.file_path }));
@@ -553,7 +557,7 @@ pub fn query_graph(
                     // then fall back to root-relative join.
                     let as_is = target.to_string();
                     if store.get_nodes_by_file(&as_is)?.is_empty() {
-                        root.join(target).to_string_lossy().into_owned()
+                        root.join(target).as_str().to_owned()
                     } else {
                         as_is
                     }
@@ -605,7 +609,7 @@ pub fn get_review_context(
     }
 
     let abs_files: Vec<String> = files.iter()
-        .map(|f| root.join(f).to_string_lossy().into_owned())
+        .map(|f| root.join(f).as_str().to_owned())
         .collect();
 
     let impact = store.get_impact_radius(&abs_files, max_depth, 500, None)?;
@@ -637,7 +641,7 @@ pub fn get_review_context(
             };
             let lines: Vec<&str> = content.lines().collect();
             let snippet = if lines.len() > max_lines_per_file {
-                extract_relevant_lines(&lines, &impact.changed_nodes, &full_path.to_string_lossy())
+                extract_relevant_lines(&lines, &impact.changed_nodes, full_path.as_str())
             } else {
                 lines.iter().enumerate()
                     .map(|(i, line)| format!("{}: {}", i + 1, line))
@@ -737,8 +741,8 @@ pub fn list_graph_stats(repo_root: Option<&str>) -> Result<Value> {
     let stats = store.get_stats()?;
 
     let root_name = root.file_name()
-        .map(|n| n.to_string_lossy().into_owned())
-        .unwrap_or_else(|| root.to_string_lossy().into_owned());
+        .map(|n| n.to_owned())
+        .unwrap_or_else(|| root.as_str().to_owned());
 
     let languages = if stats.languages.is_empty() {
         "none".to_string()
@@ -832,10 +836,10 @@ pub fn embed_graph(repo_root: Option<&str>) -> Result<Value> {
 // ---------------------------------------------------------------------------
 
 pub fn get_docs_section(section_name: &str, repo_root: Option<&str>) -> Result<Value> {
-    let mut search_roots: Vec<PathBuf> = vec![];
+    let mut search_roots: Vec<Utf8PathBuf> = vec![];
 
     if let Some(p) = repo_root {
-        search_roots.push(PathBuf::from(p));
+        search_roots.push(Utf8PathBuf::from(p));
     }
 
     if let Ok((store, root)) = get_store(repo_root) {
@@ -1009,7 +1013,7 @@ pub fn measure_token_reduction(
     // Context bytes: size of graph-filtered impact context
     let files = resolve_changed_files(changed_files, &root, base);
     let abs_files: Vec<String> = files.iter()
-        .map(|f| root.join(f).to_string_lossy().into_owned())
+        .map(|f| root.join(f).as_str().to_owned())
         .collect();
 
     let context_bytes: u64 = if abs_files.is_empty() {
@@ -1063,9 +1067,9 @@ pub fn find_large_functions(
         } else {
             0
         };
-        let relative_path = Path::new(&n.file_path)
+        let relative_path = Utf8Path::new(&n.file_path)
             .strip_prefix(&root)
-            .map(|p| p.to_string_lossy().into_owned())
+            .map(|p| p.as_str().to_owned())
             .unwrap_or_else(|_| n.file_path.clone());
         let mut d = node_dict(n, compact, &root);
         d["line_count"] = json!(line_count);
@@ -1202,7 +1206,7 @@ pub fn trace_call_chain(
 /// Resolve changed files from the provided list or from git diff.
 fn resolve_changed_files(
     changed_files: Option<Vec<String>>,
-    root: &Path,
+    root: &Utf8Path,
     base: &str,
 ) -> Vec<String> {
     if let Some(files) = changed_files {
@@ -1225,12 +1229,12 @@ enum ResolveResult {
 fn resolve_target_node(
     store: &GraphStore,
     target: &str,
-    root: &Path,
+    root: &Utf8Path,
 ) -> Result<ResolveResult> {
     if let Some(node) = store.get_node(target)? {
         return Ok(ResolveResult::Found(node));
     }
-    let abs_target = root.join(target).to_string_lossy().into_owned();
+    let abs_target = root.join(target).as_str().to_owned();
     if let Some(node) = store.get_node(&abs_target)? {
         return Ok(ResolveResult::Found(node));
     }
@@ -1362,7 +1366,7 @@ mod tests {
     fn make_git_repo() -> (TempDir, String) {
         let dir = TempDir::new().unwrap();
         fs::create_dir(dir.path().join(".git")).unwrap();
-        let path = dir.path().to_string_lossy().into_owned();
+        let path = dir.path().to_str().expect("temp dir path is valid UTF-8").to_owned();
         (dir, path)
     }
 
@@ -1370,9 +1374,13 @@ mod tests {
     // validate_repo_root
     // -----------------------------------------------------------------------
 
+    fn tp(path: &std::path::Path) -> &Utf8Path {
+        Utf8Path::from_path(path).expect("test path is valid UTF-8")
+    }
+
     #[test]
     fn validate_repo_root_rejects_nonexistent() {
-        let result = validate_repo_root(Path::new("/nonexistent/path/that/does/not/exist"));
+        let result = validate_repo_root(Utf8Path::new("/nonexistent/path/that/does/not/exist"));
         assert!(result.is_err());
     }
 
@@ -1380,14 +1388,14 @@ mod tests {
     fn validate_repo_root_rejects_dir_without_git() {
         let dir = TempDir::new().unwrap();
         // No .git, no .code-review-graph
-        let result = validate_repo_root(dir.path());
+        let result = validate_repo_root(tp(dir.path()));
         assert!(result.is_err(), "dir without .git should be rejected");
     }
 
     #[test]
     fn validate_repo_root_accepts_git_repo() {
         let (dir, _) = make_git_repo();
-        let result = validate_repo_root(dir.path());
+        let result = validate_repo_root(tp(dir.path()));
         assert!(result.is_ok(), "dir with .git should be accepted");
     }
 
@@ -1395,7 +1403,7 @@ mod tests {
     fn validate_repo_root_accepts_code_review_graph_dir() {
         let dir = TempDir::new().unwrap();
         fs::create_dir(dir.path().join(".code-review-graph")).unwrap();
-        let result = validate_repo_root(dir.path());
+        let result = validate_repo_root(tp(dir.path()));
         assert!(result.is_ok(), "dir with .code-review-graph should be accepted");
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -260,8 +260,8 @@ pub struct NormalizedPrefix {
 }
 
 impl NormalizedPrefix {
-    pub fn new(repo_root: &std::path::Path) -> Self {
-        let fwd = repo_root.to_string_lossy().replace('\\', "/");
+    pub fn new(repo_root: &camino::Utf8Path) -> Self {
+        let fwd = repo_root.as_str().replace('\\', "/");
         let fwd_unc = format!("//?/{}", fwd);
         Self { fwd, fwd_unc }
     }
@@ -285,7 +285,7 @@ impl NormalizedPrefix {
 /// Strip the repo root prefix from `file_path` and `qualified_name` fields
 /// in a node dict. For batch operations, prefer `NormalizedPrefix::new()` +
 /// `.strip()` to avoid recomputing the prefix on every node.
-pub fn strip_paths_prefix(dict: &mut serde_json::Value, repo_root: &std::path::Path) {
+pub fn strip_paths_prefix(dict: &mut serde_json::Value, repo_root: &camino::Utf8Path) {
     NormalizedPrefix::new(repo_root).strip(dict);
 }
 

--- a/src/visualization.rs
+++ b/src/visualization.rs
@@ -4,7 +4,8 @@
 //! force-directed D3.js visualization (dark theme, zoomable, draggable).
 
 use std::collections::HashSet;
-use std::path::Path;
+
+use camino::Utf8Path;
 
 use serde_json::{json, Value};
 
@@ -75,7 +76,7 @@ pub fn export_graph_data(store: &GraphStore) -> Result<Value> {
 /// Generate a self-contained interactive HTML visualization file.
 ///
 /// Writes the HTML to `output_path` and returns on success.
-pub fn generate_html(store: &GraphStore, output_path: &Path) -> Result<()> {
+pub fn generate_html(store: &GraphStore, output_path: &Utf8Path) -> Result<()> {
     let data = export_graph_data(store)?;
 
     // Escape `</script>` inside JSON to prevent premature tag closure.

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3,6 +3,7 @@
 use std::fs;
 use std::path::Path;
 
+use camino::Utf8Path;
 use code_review_graph::graph::GraphStore;
 use code_review_graph::incremental::{full_build, get_db_path, incremental_update};
 use code_review_graph::parser::CodeParser;
@@ -11,6 +12,10 @@ use code_review_graph::tools::{
     measure_token_reduction, query_graph, semantic_search_nodes, trace_call_chain,
 };
 use tempfile::TempDir;
+
+fn p(path: &std::path::Path) -> &Utf8Path {
+    Utf8Path::from_path(path).expect("test path is valid UTF-8")
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -86,10 +91,10 @@ export function farewell(name: string): string {
 fn full_build_produces_nodes_and_edges() {
     if !grammars_available() { return; }
     let dir = setup_test_repo();
-    let db_path = get_db_path(dir.path());
+    let db_path = get_db_path(p(dir.path()));
     let mut store = GraphStore::new(&db_path).unwrap();
 
-    let result = full_build(dir.path(), &mut store).unwrap();
+    let result = full_build(p(dir.path()), &mut store).unwrap();
 
     // We created 3 source files; at minimum all should parse
     assert!(result.files_parsed >= 3, "should parse at least 3 files, got {}", result.files_parsed);
@@ -140,9 +145,9 @@ fn query_graph_callers_and_callees() {
 fn incremental_update_picks_up_new_function() {
     if !grammars_available() { return; }
     let dir = setup_test_repo();
-    let db_path = get_db_path(dir.path());
+    let db_path = get_db_path(p(dir.path()));
     let mut store = GraphStore::new(&db_path).unwrap();
-    full_build(dir.path(), &mut store).unwrap();
+    full_build(p(dir.path()), &mut store).unwrap();
 
     // Add a new function to utils.py
     fs::write(
@@ -161,7 +166,7 @@ def multiply(a, b):
     .unwrap();
 
     let result = incremental_update(
-        dir.path(),
+        p(dir.path()),
         &mut store,
         "HEAD",
         Some(vec!["utils.py".to_string()]),
@@ -195,12 +200,12 @@ fn save_load_cycle_preserves_graph() {
     )
     .unwrap();
 
-    let db_path = get_db_path(dir.path());
+    let db_path = get_db_path(p(dir.path()));
 
     // Build and close (triggers save)
     {
         let mut store = GraphStore::new(&db_path).unwrap();
-        full_build(dir.path(), &mut store).unwrap();
+        full_build(p(dir.path()), &mut store).unwrap();
         // commit is called inside full_build, but call close() explicitly
         store.close().unwrap();
     }
@@ -278,9 +283,9 @@ fn list_graph_stats_after_build() {
 fn impact_radius_flags_callers_of_changed_function() {
     if !grammars_available() { return; }
     let dir = setup_test_repo();
-    let db_path = get_db_path(dir.path());
+    let db_path = get_db_path(p(dir.path()));
     let mut store = GraphStore::new(&db_path).unwrap();
-    full_build(dir.path(), &mut store).unwrap();
+    full_build(p(dir.path()), &mut store).unwrap();
 
     // utils.py contains add; main.py calls add via run() -> add()
     let abs_utils = dir.path().join("utils.py").to_string_lossy().into_owned();


### PR DESCRIPTION
## Summary

- Replace all `std::path::{Path,PathBuf}` with `camino::{Utf8Path,Utf8PathBuf}` across all 8 source files and the integration test suite
- Add `src/intern.rs`: global `ThreadedRodeo` singleton via `OnceLock` for future string interning of high-frequency fields (`language`, `file_path`)
- Add `camino = "1"` and `lasso = { version = "0.7", features = ["multi-threaded"] }` to `Cargo.toml`

## Details

**Path migration:**
- All public APIs (`full_build`, `incremental_update`, `get_db_path`, `GraphStore::new`, `EmbeddingStore::new`, etc.) now take `&Utf8Path` / return `Utf8PathBuf`
- Boundary pattern: `notify` watcher and `tree-sitter` parser still receive `&std::path::Path`; converted at call sites with `.as_std_path()`
- `Display` works directly on `Utf8Path` (no `.display()` wrapper needed)
- `.as_str()` replaces `.to_string_lossy()` where paths are guaranteed UTF-8

**String interning foundation:**
- `intern::intern(s)` / `intern::resolve(key)` wired up, not yet applied to `GraphNode` fields (that's a follow-up)

## Test plan

- [x] `cargo test` — 112 unit + 24 integration = 136 tests, all passing
- [x] `cargo build --release` — clean build, only 1 pre-existing `unused_mut` warning (conditional on `gpu-directml` feature)
- [ ] Verify `code-review-graph build` + `status` work end-to-end on a real repo after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)